### PR TITLE
サービスから受信した結果項目をクライアントへ送信する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,13 @@
     - @Hexa
 - [UPDATE] パッチで変更していた使用していないメソッド内の変更を削除する
     - @Hexa
+- [CHANGE] GCP を使用する場合のクライアントに送信される結果から channel_id の項目を削除する
+    - @Hexa
+- [CHANGE] 設定ファイルで指定されている音声解析サービスからの結果項目をクライアントへ送信する結果に含める
+    - 現在設定ファイルで指定可能な項目は下記の通り
+        - AWS: channel_id, is_partial
+        - GCP: is_final, stability
+    - @Hexa
 
 ## 2023.1.0
 

--- a/amazon_transcribe.go
+++ b/amazon_transcribe.go
@@ -160,14 +160,14 @@ L:
 			switch e := event.(type) {
 			case *transcribestreamingservice.TranscriptEvent:
 				for _, res := range e.Transcript.Results {
+					var awsResult AwsResult
+					if at.Config.AwsResultIsPartial {
+						awsResult.WithIsPartial(*res.IsPartial)
+					}
 					for _, alt := range res.Alternatives {
 						var message []byte
 						if alt.Transcript != nil {
 							message = []byte(*alt.Transcript)
-						}
-						var awsResult AwsResult
-						if at.Config.AwsResultIsPartial {
-							awsResult.WithIsPartial(*res.IsPartial)
 						}
 
 						// TODO: 他に必要なフィールドも送信する

--- a/amazon_transcribe.go
+++ b/amazon_transcribe.go
@@ -12,11 +12,10 @@ import (
 )
 
 type TranscriptionResult struct {
-	ChannelID *string     `json:"channel_id"`
-	Message   []byte      `json:"message"`
-	Error     error       `json:"error,omitempty"`
-	Result    interface{} `json:"resutl,omitempty"`
-	Type      string      `json:"type"`
+	Message []byte      `json:"message"`
+	Error   error       `json:"error,omitempty"`
+	Result  interface{} `json:"resutl,omitempty"`
+	Type    string      `json:"type"`
 }
 
 const (
@@ -142,7 +141,13 @@ func (at *AmazonTranscribe) Close() error {
 }
 
 type AwsResult struct {
-	IsPartial *bool `json:"is_partial,omitempty"`
+	ChannelID *string `json:"channel_id,omitempty"`
+	IsPartial *bool   `json:"is_partial,omitempty"`
+}
+
+func (ar *AwsResult) WithChannelID(channelID string) *AwsResult {
+	ar.ChannelID = &channelID
+	return ar
 }
 
 func (ar *AwsResult) WithIsPartial(isPartial bool) *AwsResult {
@@ -164,6 +169,9 @@ L:
 					if at.Config.AwsResultIsPartial {
 						awsResult.WithIsPartial(*res.IsPartial)
 					}
+					if at.Config.AwsResultChannelID {
+						awsResult.WithChannelID(*res.ChannelId)
+					}
 					for _, alt := range res.Alternatives {
 						var message []byte
 						if alt.Transcript != nil {
@@ -172,10 +180,9 @@ L:
 
 						// TODO: 他に必要なフィールドも送信する
 						at.ResultCh <- TranscriptionResult{
-							Type:      "aws",
-							ChannelID: res.ChannelId,
-							Message:   message,
-							Result:    awsResult,
+							Type:    "aws",
+							Message: message,
+							Result:  awsResult,
 						}
 					}
 				}

--- a/amazon_transcribe.go
+++ b/amazon_transcribe.go
@@ -12,10 +12,9 @@ import (
 )
 
 type TranscriptionResult struct {
-	Message      string `json:"message,omitempty"`
-	Error        error  `json:"-"`
-	ErrorMessage string `json:"error,omitempty"`
-	Type         string `json:"type"`
+	Message string `json:"message,omitempty"`
+	Error   error  `json:"error,omitempty"`
+	Type    string `json:"type"`
 }
 
 const (
@@ -149,9 +148,8 @@ type AwsResult struct {
 func AwsErrorResult(err error) AwsResult {
 	return AwsResult{
 		TranscriptionResult: TranscriptionResult{
-			Type:         "aws",
-			Error:        err,
-			ErrorMessage: err.Error(),
+			Type:  "aws",
+			Error: err,
 		},
 	}
 }

--- a/amazon_transcribe.go
+++ b/amazon_transcribe.go
@@ -165,12 +165,12 @@ L:
 			switch e := event.(type) {
 			case *transcribestreamingservice.TranscriptEvent:
 				for _, res := range e.Transcript.Results {
-					var awsResult AwsResult
+					var result AwsResult
 					if at.Config.AwsResultIsPartial {
-						awsResult.WithIsPartial(*res.IsPartial)
+						result.WithIsPartial(*res.IsPartial)
 					}
 					if at.Config.AwsResultChannelID {
-						awsResult.WithChannelID(*res.ChannelId)
+						result.WithChannelID(*res.ChannelId)
 					}
 					for _, alt := range res.Alternatives {
 						var message []byte
@@ -182,7 +182,7 @@ L:
 						at.ResultCh <- TranscriptionResult{
 							Type:    "aws",
 							Message: message,
-							Result:  awsResult,
+							Result:  result,
 						}
 					}
 				}

--- a/amazon_transcribe_handler.go
+++ b/amazon_transcribe_handler.go
@@ -52,10 +52,9 @@ func AmazonTranscribeHandler(ctx context.Context, conn io.Reader, args HandlerAr
 			}
 
 			res := Response{
-				ChannelID: tr.ChannelID,
-				Message:   string(tr.Message),
-				Result:    &tr.Result,
-				Type:      tr.Type,
+				Message: string(tr.Message),
+				Result:  &tr.Result,
+				Type:    tr.Type,
 			}
 			if err := encoder.Encode(res); err != nil {
 				w.CloseWithError(err)

--- a/amazon_transcribe_handler.go
+++ b/amazon_transcribe_handler.go
@@ -52,9 +52,9 @@ func AmazonTranscribeHandler(ctx context.Context, conn io.Reader, args HandlerAr
 			}
 
 			res := Response{
-				Message: string(tr.Message),
-				Result:  &tr.Result,
-				Type:    tr.Type,
+				Message:       string(tr.Message),
+				ServiceResult: &tr.Result,
+				Type:          tr.Type,
 			}
 			if err := encoder.Encode(res); err != nil {
 				w.CloseWithError(err)

--- a/amazon_transcribe_handler.go
+++ b/amazon_transcribe_handler.go
@@ -54,6 +54,8 @@ func AmazonTranscribeHandler(ctx context.Context, conn io.Reader, args HandlerAr
 			res := Response{
 				ChannelID: tr.ChannelID,
 				Message:   string(tr.Message),
+				Result:    &tr.Result,
+				Type:      tr.Type,
 			}
 			if err := encoder.Encode(res); err != nil {
 				w.CloseWithError(err)

--- a/config.example.toml
+++ b/config.example.toml
@@ -49,6 +49,10 @@ aws_credential_file = "./credentials"
 # 認証情報に AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY を使用する場合は、下記のプロファイルの指定行をコメントアウトします
 aws_profile = "default"
 
+# クライアントに送る変換結果の情報に付与する項目
+aws_result_channel_id = true
+# aws_result_is_partial = true
+
 
 # https://cloud.google.com/speech-to-text/docs/reference/rpc/google.cloud.speech.v1#streamingrecognitionconfig
 # https://cloud.google.com/speech-to-text/docs/reference/rpc/google.cloud.speech.v1#recognitionconfig
@@ -69,3 +73,6 @@ gcp_credential_file = ""
 # gcp_enable_spoken_punctuation = false
 # gcp_model = "default"
 # gcp_use_enhanced = false
+# クライアントに送る変換結果の情報に付与する項目
+# gcp_result_is_final = true
+# gcp_result_stability = true

--- a/config.go
+++ b/config.go
@@ -68,6 +68,8 @@ type Config struct {
 	GcpUseEnhanced                         bool     `toml:"gcp_use_enhanced"`
 	GcpSingleUtterance                     bool     `toml:"gcp_single_utterance"`
 	GcpInterimResults                      bool     `toml:"gcp_interim_results"`
+	GcpResultIsFinal                       bool     `toml:"gcp_result_is_final"`
+	GcpResultStability                     bool     `toml:"gcp_result_stability"`
 }
 
 func InitConfig(data []byte, config *Config) error {

--- a/config.go
+++ b/config.go
@@ -51,6 +51,7 @@ type Config struct {
 	AwsEnablePartialResultsStabilization bool   `toml:"aws_enable_partial_results_stabilization"`
 	AwsPartialResultsStability           string `toml:"aws_partial_results_stability"`
 	AwsEnableChannelIdentification       bool   `toml:"aws_enable_channel_identification"`
+	AwsResultIsPartial                   bool   `toml:"aws_result_is_partial"`
 
 	// Google Cloud Platform
 	GcpCredentialFile                      string   `toml:"gcp_credential_file"`

--- a/config.go
+++ b/config.go
@@ -51,7 +51,9 @@ type Config struct {
 	AwsEnablePartialResultsStabilization bool   `toml:"aws_enable_partial_results_stabilization"`
 	AwsPartialResultsStability           string `toml:"aws_partial_results_stability"`
 	AwsEnableChannelIdentification       bool   `toml:"aws_enable_channel_identification"`
-	AwsResultIsPartial                   bool   `toml:"aws_result_is_partial"`
+	// 変換結果に含める項目の有無の指定
+	AwsResultChannelID bool `toml:"aws_result_channel_id"`
+	AwsResultIsPartial bool `toml:"aws_result_is_partial"`
 
 	// Google Cloud Platform
 	GcpCredentialFile                      string   `toml:"gcp_credential_file"`
@@ -68,8 +70,9 @@ type Config struct {
 	GcpUseEnhanced                         bool     `toml:"gcp_use_enhanced"`
 	GcpSingleUtterance                     bool     `toml:"gcp_single_utterance"`
 	GcpInterimResults                      bool     `toml:"gcp_interim_results"`
-	GcpResultIsFinal                       bool     `toml:"gcp_result_is_final"`
-	GcpResultStability                     bool     `toml:"gcp_result_stability"`
+	// 変換結果に含める項目の有無の指定
+	GcpResultIsFinal   bool `toml:"gcp_result_is_final"`
+	GcpResultStability bool `toml:"gcp_result_stability"`
 }
 
 func InitConfig(data []byte, config *Config) error {

--- a/handler.go
+++ b/handler.go
@@ -175,11 +175,10 @@ func opus2ogg(ctx context.Context, opusReader io.Reader, oggWriter io.Writer, sa
 }
 
 type Response struct {
-	ChannelID *string     `json:"channel_id"`
-	Message   string      `json:"message"`
-	Error     error       `json:"error,omitempty"`
-	Result    interface{} `json:"result,omitempty"`
-	Type      string      `json:"type"`
+	Message string      `json:"message"`
+	Error   error       `json:"error,omitempty"`
+	Result  interface{} `json:"result,omitempty"`
+	Type    string      `json:"type"`
 }
 
 func readerWithSilentPacketFromOpusReader(d time.Duration, opusReader io.Reader) (io.Reader, error) {

--- a/handler.go
+++ b/handler.go
@@ -174,13 +174,6 @@ func opus2ogg(ctx context.Context, opusReader io.Reader, oggWriter io.Writer, sa
 	}
 }
 
-type Response struct {
-	Message       string      `json:"message"`
-	Error         error       `json:"error,omitempty"`
-	ServiceResult interface{} `json:"service_result,omitempty"`
-	Type          string      `json:"type"`
-}
-
 func readerWithSilentPacketFromOpusReader(d time.Duration, opusReader io.Reader) (io.Reader, error) {
 	type reqeust struct {
 		Payload []byte

--- a/handler.go
+++ b/handler.go
@@ -175,9 +175,11 @@ func opus2ogg(ctx context.Context, opusReader io.Reader, oggWriter io.Writer, sa
 }
 
 type Response struct {
-	ChannelID *string `json:"channel_id"`
-	Message   string  `json:"message"`
-	Error     error   `json:"error,omitempty"`
+	ChannelID *string     `json:"channel_id"`
+	Message   string      `json:"message"`
+	Error     error       `json:"error,omitempty"`
+	Result    interface{} `json:"result,omitempty"`
+	Type      string      `json:"type"`
 }
 
 func readerWithSilentPacketFromOpusReader(d time.Duration, opusReader io.Reader) (io.Reader, error) {

--- a/handler.go
+++ b/handler.go
@@ -175,10 +175,10 @@ func opus2ogg(ctx context.Context, opusReader io.Reader, oggWriter io.Writer, sa
 }
 
 type Response struct {
-	Message string      `json:"message"`
-	Error   error       `json:"error,omitempty"`
-	Result  interface{} `json:"result,omitempty"`
-	Type    string      `json:"type"`
+	Message       string      `json:"message"`
+	Error         error       `json:"error,omitempty"`
+	ServiceResult interface{} `json:"service_result,omitempty"`
+	Type          string      `json:"type"`
 }
 
 func readerWithSilentPacketFromOpusReader(d time.Duration, opusReader io.Reader) (io.Reader, error) {

--- a/handler_test.go
+++ b/handler_test.go
@@ -131,7 +131,7 @@ func TestSpeechHandler(t *testing.T) {
 					t.Error(err)
 				}
 
-				assert.NotEmpty(t, response.ChannelID)
+				assert.NotNil(t, response.Result)
 				assert.NotEmpty(t, response.Message)
 			}
 		}
@@ -359,7 +359,7 @@ func TestSpeechHandler(t *testing.T) {
 					t.Error(err)
 				}
 
-				assert.NotEmpty(t, response.ChannelID)
+				assert.NotNil(t, response.Result)
 				assert.NotEmpty(t, response.Message)
 			}
 		}

--- a/handler_test.go
+++ b/handler_test.go
@@ -126,13 +126,13 @@ func TestSpeechHandler(t *testing.T) {
 					}
 					break
 				}
-				response := Response{}
-				if err := json.Unmarshal(line, &response); err != nil {
+				var result TranscriptionResult
+				if err := json.Unmarshal(line, &result); err != nil {
 					t.Error(err)
 				}
 
-				assert.NotNil(t, response.ServiceResult)
-				assert.NotEmpty(t, response.Message)
+				assert.Equal(t, "test", result.Type)
+				assert.NotEmpty(t, result.Message)
 			}
 		}
 
@@ -354,13 +354,13 @@ func TestSpeechHandler(t *testing.T) {
 					}
 					break
 				}
-				response := Response{}
-				if err := json.Unmarshal(line, &response); err != nil {
+				var result TranscriptionResult
+				if err := json.Unmarshal(line, &result); err != nil {
 					t.Error(err)
 				}
 
-				assert.NotNil(t, response.ServiceResult)
-				assert.NotEmpty(t, response.Message)
+				assert.Equal(t, "test", result.Type)
+				assert.NotEmpty(t, result.Message)
 			}
 		}
 

--- a/handler_test.go
+++ b/handler_test.go
@@ -131,7 +131,7 @@ func TestSpeechHandler(t *testing.T) {
 					t.Error(err)
 				}
 
-				assert.NotNil(t, response.Result)
+				assert.NotNil(t, response.ServiceResult)
 				assert.NotEmpty(t, response.Message)
 			}
 		}
@@ -359,7 +359,7 @@ func TestSpeechHandler(t *testing.T) {
 					t.Error(err)
 				}
 
-				assert.NotNil(t, response.Result)
+				assert.NotNil(t, response.ServiceResult)
 				assert.NotEmpty(t, response.Message)
 			}
 		}

--- a/speech_to_text.go
+++ b/speech_to_text.go
@@ -12,10 +12,14 @@ import (
 	speechpb "cloud.google.com/go/speech/apiv1/speechpb"
 )
 
-type SpeechToText struct{}
+type SpeechToText struct {
+	Config Config
+}
 
-func NewSpeechToText() SpeechToText {
-	return SpeechToText{}
+func NewSpeechToText(config Config) SpeechToText {
+	return SpeechToText{
+		Config: config,
+	}
 }
 
 func (stt SpeechToText) Start(ctx context.Context, config Config, args HandlerArgs, r io.Reader) (speechpb.Speech_StreamingRecognizeClient, error) {

--- a/speech_to_text_handler.go
+++ b/speech_to_text_handler.go
@@ -103,9 +103,9 @@ func SpeechToTextHandler(ctx context.Context, conn io.Reader, args HandlerArgs) 
 					}
 					transcript := alternative.Transcript
 					resp := Response{
-						Message: transcript,
-						Result:  result,
-						Type:    "gcp",
+						Message:       transcript,
+						ServiceResult: result,
+						Type:          "gcp",
 					}
 					if err := encoder.Encode(resp); err != nil {
 						w.CloseWithError(err)

--- a/speech_to_text_handler.go
+++ b/speech_to_text_handler.go
@@ -79,16 +79,16 @@ func SpeechToTextHandler(ctx context.Context, conn io.Reader, args HandlerArgs) 
 				return
 			}
 
-			for _, result := range resp.Results {
-				var gcpResult GcpResult
+			for _, res := range resp.Results {
+				var result GcpResult
 				if stt.Config.GcpResultIsFinal {
-					gcpResult.WithIsFinal(result.IsFinal)
+					result.WithIsFinal(res.IsFinal)
 				}
 				if stt.Config.GcpResultStability {
-					gcpResult.WithStability(result.Stability)
+					result.WithStability(res.Stability)
 				}
 
-				for _, alternative := range result.Alternatives {
+				for _, alternative := range res.Alternatives {
 					if args.Config.GcpEnableWordConfidence {
 						for _, word := range alternative.Words {
 							zlog.Debug().
@@ -104,7 +104,7 @@ func SpeechToTextHandler(ctx context.Context, conn io.Reader, args HandlerArgs) 
 					transcript := alternative.Transcript
 					resp := Response{
 						Message: transcript,
-						Result:  gcpResult,
+						Result:  result,
 						Type:    "gcp",
 					}
 					if err := encoder.Encode(resp); err != nil {

--- a/speech_to_text_handler.go
+++ b/speech_to_text_handler.go
@@ -22,9 +22,8 @@ type GcpResult struct {
 func GcpErrorResult(err error) GcpResult {
 	return GcpResult{
 		TranscriptionResult: TranscriptionResult{
-			Type:         "gcp",
-			Error:        err,
-			ErrorMessage: err.Error(),
+			Type:  "gcp",
+			Error: err,
 		},
 	}
 }

--- a/test_handler.go
+++ b/test_handler.go
@@ -49,7 +49,7 @@ func TestHandler(ctx context.Context, opusReader io.Reader, args HandlerArgs) (*
 			if n > 0 {
 				res := Response{
 					Message: fmt.Sprintf("n: %d", n),
-					Result: TestResult{
+					ServiceResult: TestResult{
 						ChannelID: &[]string{"ch_0"}[0],
 					},
 				}

--- a/test_handler.go
+++ b/test_handler.go
@@ -10,6 +10,17 @@ import (
 
 type TestResult struct {
 	ChannelID *string `json:"channel_id,omitempty"`
+	TranscriptionResult
+}
+
+func TestErrorResult(err error) TestResult {
+	return TestResult{
+		TranscriptionResult: TranscriptionResult{
+			Type:         "test",
+			Error:        err,
+			ErrorMessage: err.Error(),
+		},
+	}
 }
 
 func TestHandler(ctx context.Context, opusReader io.Reader, args HandlerArgs) (*io.PipeReader, error) {
@@ -47,13 +58,11 @@ func TestHandler(ctx context.Context, opusReader io.Reader, args HandlerArgs) (*
 			}
 
 			if n > 0 {
-				res := Response{
-					Message: fmt.Sprintf("n: %d", n),
-					ServiceResult: TestResult{
-						ChannelID: &[]string{"ch_0"}[0],
-					},
-				}
-				if err := encoder.Encode(res); err != nil {
+				var result TestResult
+				result.Type = "test"
+				result.Message = fmt.Sprintf("n: %d", n)
+				result.ChannelID = &[]string{"ch_0"}[0]
+				if err := encoder.Encode(result); err != nil {
 					w.CloseWithError(err)
 					return
 				}

--- a/test_handler.go
+++ b/test_handler.go
@@ -8,6 +8,10 @@ import (
 	"time"
 )
 
+type TestResult struct {
+	ChannelID *string `json:"channel_id,omitempty"`
+}
+
 func TestHandler(ctx context.Context, opusReader io.Reader, args HandlerArgs) (*io.PipeReader, error) {
 	c := args.Config
 
@@ -44,8 +48,10 @@ func TestHandler(ctx context.Context, opusReader io.Reader, args HandlerArgs) (*
 
 			if n > 0 {
 				res := Response{
-					ChannelID: &[]string{"ch_0"}[0],
-					Message:   fmt.Sprintf("n: %d", n),
+					Message: fmt.Sprintf("n: %d", n),
+					Result: TestResult{
+						ChannelID: &[]string{"ch_0"}[0],
+					},
 				}
 				if err := encoder.Encode(res); err != nil {
 					w.CloseWithError(err)

--- a/test_handler.go
+++ b/test_handler.go
@@ -16,9 +16,8 @@ type TestResult struct {
 func TestErrorResult(err error) TestResult {
 	return TestResult{
 		TranscriptionResult: TranscriptionResult{
-			Type:         "test",
-			Error:        err,
-			ErrorMessage: err.Error(),
+			Type:  "test",
+			Error: err,
 		},
 	}
 }


### PR DESCRIPTION
サービスから受信した結果項目の一部を、クライアントに送るようにします

- 送る項目は設定ファイルで指定する
- 現時点では aws, gcp で指定可能な項目は下記の通り
  - aws
    - channel_id
    - is_partial
  - gcp
    - is_final
    - stability
- /test では既存に合わせて channel_id に固定値を付与してクライアントに送信する
    - 設定ファイルでの指定対象外