### PR TITLE
Feature/refactoring

### DIFF
--- a/amazon_transcribe.go
+++ b/amazon_transcribe.go
@@ -2,7 +2,6 @@ package suzu
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"net/http"
 
@@ -12,18 +11,16 @@ import (
 )
 
 type AmazonTranscribe struct {
-	LanguageCode                        string
-	MediaEncoding                       string
-	MediaSampleRateHertz                int64
-	EnablePartialResultsStabilization   bool
-	NumberOfChannels                    int64
-	EnableChannelIdentification         bool
-	PartialResultsStability             string
-	Region                              string
-	Debug                               bool
-	StartStreamTranscriptionEventStream *transcribestreamingservice.StartStreamTranscriptionEventStream
-	ResultCh                            chan AwsResult
-	Config                              Config
+	LanguageCode                      string
+	MediaEncoding                     string
+	MediaSampleRateHertz              int64
+	EnablePartialResultsStabilization bool
+	NumberOfChannels                  int64
+	EnableChannelIdentification       bool
+	PartialResultsStability           string
+	Region                            string
+	Debug                             bool
+	Config                            Config
 }
 
 func NewAmazonTranscribe(config Config, languageCode string, sampleRateHertz, audioChannelCount int64) *AmazonTranscribe {
@@ -36,7 +33,6 @@ func NewAmazonTranscribe(config Config, languageCode string, sampleRateHertz, au
 		PartialResultsStability:           config.AwsPartialResultsStability,
 		NumberOfChannels:                  audioChannelCount,
 		EnableChannelIdentification:       config.AwsEnableChannelIdentification,
-		ResultCh:                          make(chan AwsResult),
 		Config:                            config,
 	}
 }
@@ -92,41 +88,26 @@ func NewAmazonTranscribeClient(config Config) *transcribestreamingservice.Transc
 	return transcribestreamingservice.New(sess, cfg)
 }
 
-func (at *AmazonTranscribe) Start(ctx context.Context, config Config, r io.Reader) error {
-	if err := at.startTranscribeService(ctx, config); err != nil {
-		return err
-	}
-
-	if err := at.streamAudioFromReader(ctx, r, FrameSize); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (at *AmazonTranscribe) startTranscribeService(ctx context.Context, config Config) error {
-
+func (at *AmazonTranscribe) Start(ctx context.Context, config Config, r io.Reader) (*transcribestreamingservice.StartStreamTranscriptionEventStream, error) {
 	client := NewAmazonTranscribeClient(config)
 	input := NewStartStreamTranscriptionInput(at)
 
 	resp, err := client.StartStreamTranscriptionWithContext(ctx, &input)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	stream := resp.GetStream()
-	at.StartStreamTranscriptionEventStream = stream
 
-	go at.ReceiveResults(ctx)
+	go func() {
+		defer stream.Close()
 
-	return nil
-}
+		if err := transcribestreamingservice.StreamAudioFromReader(ctx, stream, FrameSize, r); err != nil {
+			return
+		}
+	}()
 
-func (at *AmazonTranscribe) Close() error {
-	if at.StartStreamTranscriptionEventStream != nil {
-		return at.StartStreamTranscriptionEventStream.Close()
-	}
-	return nil
+	return stream, nil
 }
 
 type AwsResult struct {
@@ -152,56 +133,4 @@ func (ar *AwsResult) WithChannelID(channelID string) *AwsResult {
 func (ar *AwsResult) WithIsPartial(isPartial bool) *AwsResult {
 	ar.IsPartial = &isPartial
 	return ar
-}
-
-func (at *AmazonTranscribe) ReceiveResults(ctx context.Context) {
-L:
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case event := <-at.StartStreamTranscriptionEventStream.Events():
-			switch e := event.(type) {
-			case *transcribestreamingservice.TranscriptEvent:
-				for _, res := range e.Transcript.Results {
-					var result AwsResult
-					result.Type = "aws"
-					if at.Config.AwsResultIsPartial {
-						result.WithIsPartial(*res.IsPartial)
-					}
-					if at.Config.AwsResultChannelID {
-						result.WithChannelID(*res.ChannelId)
-					}
-					for _, alt := range res.Alternatives {
-						var message string
-						if alt.Transcript != nil {
-							message = *alt.Transcript
-						}
-						result.Message = message
-
-						at.ResultCh <- result
-					}
-				}
-			default:
-				break L
-			}
-		}
-	}
-
-	if err := at.StartStreamTranscriptionEventStream.Err(); err != nil {
-		err := fmt.Errorf("UNEXPECTED-STREAM-EVENT: %w", err)
-		at.ResultCh <- AwsErrorResult(err)
-		return
-	}
-
-	// io.EOF の場合は err は nil になるため明示的に io.EOF を送る
-	at.ResultCh <- AwsErrorResult(io.EOF)
-
-}
-
-func (at *AmazonTranscribe) streamAudioFromReader(ctx context.Context, r io.Reader, frameSize int) error {
-	if err := transcribestreamingservice.StreamAudioFromReader(ctx, at.StartStreamTranscriptionEventStream, frameSize, r); err != nil {
-		return err
-	}
-	return nil
 }

--- a/amazon_transcribe.go
+++ b/amazon_transcribe.go
@@ -11,16 +11,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/transcribestreamingservice"
 )
 
-type TranscriptionResult struct {
-	Message string `json:"message,omitempty"`
-	Error   error  `json:"error,omitempty"`
-	Type    string `json:"type"`
-}
-
-const (
-	FrameSize = 1024 * 10
-)
-
 type AmazonTranscribe struct {
 	LanguageCode                        string
 	MediaEncoding                       string

--- a/amazon_transcribe_handler.go
+++ b/amazon_transcribe_handler.go
@@ -4,22 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"time"
 )
 
 func init() {
 	ServiceHandlers.registerHandler("aws", AmazonTranscribeHandler)
 }
 
-func AmazonTranscribeHandler(ctx context.Context, conn io.Reader, args HandlerArgs) (*io.PipeReader, error) {
+func AmazonTranscribeHandler(ctx context.Context, reader io.Reader, args HandlerArgs) (*io.PipeReader, error) {
 	at := NewAmazonTranscribe(args.Config, args.LanguageCode, int64(args.SampleRate), int64(args.ChannelCount))
-
-	d := time.Duration(args.Config.TimeToWaitForOpusPacketMs) * time.Millisecond
-
-	reader, err := readerWithSilentPacketFromOpusReader(d, conn)
-	if err != nil {
-		return nil, err
-	}
 
 	oggReader, oggWriter := io.Pipe()
 	go func() {

--- a/amazon_transcribe_handler.go
+++ b/amazon_transcribe_handler.go
@@ -3,7 +3,6 @@ package suzu
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 
 	"github.com/aws/aws-sdk-go/service/transcribestreamingservice"
@@ -39,7 +38,7 @@ func AmazonTranscribeHandler(ctx context.Context, reader io.Reader, args Handler
 		for {
 			select {
 			case <-ctx.Done():
-				return
+				break L
 			case event := <-stream.Events():
 				switch e := event.(type) {
 				case *transcribestreamingservice.TranscriptEvent:
@@ -71,10 +70,11 @@ func AmazonTranscribeHandler(ctx context.Context, reader io.Reader, args Handler
 		}
 
 		if err := stream.Err(); err != nil {
-			err := fmt.Errorf("UNEXPECTED-STREAM-EVENT: %w", err)
 			w.CloseWithError(err)
 			return
 		}
+
+		w.Close()
 	}()
 
 	return r, nil

--- a/amazon_transcribe_handler.go
+++ b/amazon_transcribe_handler.go
@@ -3,7 +3,10 @@ package suzu
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
+
+	"github.com/aws/aws-sdk-go/service/transcribestreamingservice"
 )
 
 func init() {
@@ -11,40 +14,66 @@ func init() {
 }
 
 func AmazonTranscribeHandler(ctx context.Context, reader io.Reader, args HandlerArgs) (*io.PipeReader, error) {
-	at := NewAmazonTranscribe(args.Config, args.LanguageCode, int64(args.SampleRate), int64(args.ChannelCount))
-
 	oggReader, oggWriter := io.Pipe()
 	go func() {
+		defer oggWriter.Close()
 		if err := opus2ogg(ctx, reader, oggWriter, args.SampleRate, args.ChannelCount, args.Config); err != nil {
 			oggWriter.CloseWithError(err)
 			return
 		}
-		oggWriter.Close()
 	}()
 
-	go func() {
-		defer at.Close()
-
-		if err := at.Start(ctx, args.Config, oggReader); err != nil {
-			at.ResultCh <- AwsErrorResult(err)
-			return
-		}
-	}()
+	at := NewAmazonTranscribe(args.Config, args.LanguageCode, int64(args.SampleRate), int64(args.ChannelCount))
+	stream, err := at.Start(ctx, args.Config, oggReader)
+	if err != nil {
+		oggWriter.CloseWithError(err)
+		return nil, err
+	}
 
 	r, w := io.Pipe()
+
 	go func() {
 		encoder := json.NewEncoder(w)
 
-		for result := range at.ResultCh {
-			if err := result.Error; err != nil {
-				w.CloseWithError(err)
+	L:
+		for {
+			select {
+			case <-ctx.Done():
 				return
+			case event := <-stream.Events():
+				switch e := event.(type) {
+				case *transcribestreamingservice.TranscriptEvent:
+					for _, res := range e.Transcript.Results {
+						var result AwsResult
+						result.Type = "aws"
+						if at.Config.AwsResultIsPartial {
+							result.WithIsPartial(*res.IsPartial)
+						}
+						if at.Config.AwsResultChannelID {
+							result.WithChannelID(*res.ChannelId)
+						}
+						for _, alt := range res.Alternatives {
+							var message string
+							if alt.Transcript != nil {
+								message = *alt.Transcript
+							}
+							result.Message = message
+							if err := encoder.Encode(result); err != nil {
+								w.CloseWithError(err)
+								return
+							}
+						}
+					}
+				default:
+					break L
+				}
 			}
+		}
 
-			if err := encoder.Encode(result); err != nil {
-				w.CloseWithError(err)
-				return
-			}
+		if err := stream.Err(); err != nil {
+			err := fmt.Errorf("UNEXPECTED-STREAM-EVENT: %w", err)
+			w.CloseWithError(err)
+			return
 		}
 	}()
 

--- a/handler.go
+++ b/handler.go
@@ -13,6 +13,16 @@ import (
 	zlog "github.com/rs/zerolog/log"
 )
 
+const (
+	FrameSize = 1024 * 10
+)
+
+type TranscriptionResult struct {
+	Message string `json:"message,omitempty"`
+	Error   error  `json:"error,omitempty"`
+	Type    string `json:"type"`
+}
+
 // https://echo.labstack.com/cookbook/streaming-response/
 // TODO(v): http/2 の streaming を使ってレスポンスを戻す方法を調べる
 

--- a/languages.go
+++ b/languages.go
@@ -7,14 +7,14 @@ import (
 )
 
 var (
-	ErrMissinuAudioStreamingLanguageCode = fmt.Errorf("MISSING-SORA-AUDIO-STREAMING-LANGUAGE-CODE")
+	ErrMissingAudioStreamingLanguageCode = fmt.Errorf("MISSING-SORA-AUDIO-STREAMING-LANGUAGE-CODE")
 	ErrUnsupportedLanguageCode           = fmt.Errorf("UNSUPPORTED-LANGUAGE-CODE")
 	ErrUnsupportedService                = fmt.Errorf("UNSUPPORTED-SERVICE")
 )
 
 func GetLanguageCode(serviceType, lang string, f func(string) (string, error)) (string, error) {
 	if lang == "" {
-		return "", ErrMissinuAudioStreamingLanguageCode
+		return "", ErrMissingAudioStreamingLanguageCode
 	}
 
 	if f != nil {

--- a/speech_to_text.go
+++ b/speech_to_text.go
@@ -13,17 +13,23 @@ import (
 )
 
 type SpeechToText struct {
-	Config Config
+	SampleReate  int32
+	ChannelCount int32
+	LanguageCode string
+	Config       Config
 }
 
-func NewSpeechToText(config Config) SpeechToText {
+func NewSpeechToText(config Config, languageCode string, sampleRate, channelCount int32) SpeechToText {
 	return SpeechToText{
-		Config: config,
+		LanguageCode: languageCode,
+		SampleReate:  sampleRate,
+		ChannelCount: channelCount,
+		Config:       config,
 	}
 }
 
-func (stt SpeechToText) Start(ctx context.Context, config Config, args HandlerArgs, r io.Reader) (speechpb.Speech_StreamingRecognizeClient, error) {
-	recognitionConfig := NewRecognitionConfig(config, args)
+func (stt SpeechToText) Start(ctx context.Context, config Config, r io.Reader) (speechpb.Speech_StreamingRecognizeClient, error) {
+	recognitionConfig := NewRecognitionConfig(config, stt.LanguageCode, int32(config.SampleRate), int32(config.ChannelCount))
 	speechpbRecognitionConfig := NewSpeechpbRecognitionConfig(recognitionConfig)
 	streamingRecognitionConfig := NewStreamingRecognitionConfig(speechpbRecognitionConfig, config.GcpSingleUtterance, config.GcpInterimResults)
 
@@ -97,13 +103,13 @@ type RecognitionConfig struct {
 	UseEnhanced                         bool
 }
 
-func NewRecognitionConfig(c Config, args HandlerArgs) RecognitionConfig {
+func NewRecognitionConfig(c Config, languageCode string, sampleRate, channelCount int32) RecognitionConfig {
 	return RecognitionConfig{
 		Encoding:                            speechpb.RecognitionConfig_OGG_OPUS,
-		SampleRateHertz:                     int32(args.SampleRate),
-		AudioChannelCount:                   int32(args.ChannelCount),
+		SampleRateHertz:                     sampleRate,
+		AudioChannelCount:                   channelCount,
 		EnableSeparateRecognitionPerChannel: c.GcpEnableSeparateRecognitionPerChannel,
-		LanguageCode:                        args.LanguageCode,
+		LanguageCode:                        languageCode,
 		AlternativeLanguageCodes:            c.GcpAlternativeLanguageCodes,
 		MaxAlternatives:                     c.GcpMaxAlternatives,
 		ProfanityFilter:                     c.GcpProfanityFilter,

--- a/speech_to_text_handler.go
+++ b/speech_to_text_handler.go
@@ -48,8 +48,8 @@ func SpeechToTextHandler(ctx context.Context, reader io.Reader, args HandlerArgs
 		}
 	}()
 
-	stt := NewSpeechToText(args.Config)
-	stream, err := stt.Start(ctx, args.Config, args, oggReader)
+	stt := NewSpeechToText(args.Config, args.LanguageCode, int32(args.SampleRate), int32(args.ChannelCount))
+	stream, err := stt.Start(ctx, args.Config, oggReader)
 	if err != nil {
 		oggWriter.CloseWithError(err)
 		return nil, err

--- a/speech_to_text_handler.go
+++ b/speech_to_text_handler.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"time"
 
 	zlog "github.com/rs/zerolog/log"
 )
@@ -38,15 +37,7 @@ func (gr *GcpResult) WithStability(stability float32) *GcpResult {
 	return gr
 }
 
-func SpeechToTextHandler(ctx context.Context, conn io.Reader, args HandlerArgs) (*io.PipeReader, error) {
-
-	d := time.Duration(args.Config.TimeToWaitForOpusPacketMs) * time.Millisecond
-
-	reader, err := readerWithSilentPacketFromOpusReader(d, conn)
-	if err != nil {
-		return nil, err
-	}
-
+func SpeechToTextHandler(ctx context.Context, reader io.Reader, args HandlerArgs) (*io.PipeReader, error) {
 	oggReader, oggWriter := io.Pipe()
 
 	go func() {

--- a/speech_to_text_handler.go
+++ b/speech_to_text_handler.go
@@ -66,15 +66,15 @@ func SpeechToTextHandler(ctx context.Context, reader io.Reader, args HandlerArgs
 				w.CloseWithError(err)
 				return
 			}
-			if err := resp.Error; err != nil {
+			if status := resp.Error; err != nil {
 				// TODO: 音声の長さの上限値に達した場合の処理の追加
 				// if err.Code == 3 || err.Code == 11 {
 				// }
 				zlog.Error().
 					Str("CHANNEL-ID", args.SoraChannelID).
 					Str("CONNECTION-ID", args.SoraConnectionID).
-					Str("MESSAGE", err.GetMessage()).
-					Int32("CODE", err.GetCode()).
+					Str("MESSAGE", status.GetMessage()).
+					Int32("CODE", status.GetCode()).
 					Send()
 				w.Close()
 				return

--- a/test_handler.go
+++ b/test_handler.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"time"
 )
 
 type TestResult struct {
@@ -22,16 +21,7 @@ func TestErrorResult(err error) TestResult {
 	}
 }
 
-func TestHandler(ctx context.Context, opusReader io.Reader, args HandlerArgs) (*io.PipeReader, error) {
-	c := args.Config
-
-	d := time.Duration(c.TimeToWaitForOpusPacketMs) * time.Millisecond
-
-	reader, err := readerWithSilentPacketFromOpusReader(d, opusReader)
-	if err != nil {
-		return nil, err
-	}
-
+func TestHandler(ctx context.Context, reader io.Reader, args HandlerArgs) (*io.PipeReader, error) {
 	oggReader, oggWriter := io.Pipe()
 
 	go func() {


### PR DESCRIPTION
内部の各処理を整理しています

- silent packet 追加の処理を handler.go でまとめて処理するように変更
- 共通で使用する定数、struct を handler.go へ移動
- aws, gcp の handler で呼び出すメソッドのインターフェースをできる限り同じ内容に変更
- silent packet 処理で冗長な箇所を整理
- 誤記や不適切な変数名を修正・変更