### PR TITLE
再接続処理有無の設定を追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,8 @@
         - AWS: LimitExceededException, InternalFailureException
         - GCP: OutOfRange, InvalidArgument, ResourceExhausted
     - @Hexa
+- [ADD] サーバから切断された際に再度接続する処理の有無を指定する設定を追加する
+    - @Hexa
 
 
 ## 2023.1.0

--- a/config.example.toml
+++ b/config.example.toml
@@ -25,6 +25,9 @@ http2_privkey_file = ""
 # クライアント認証用の CA 証明書ファイルです
 http2_verify_cacert_path = ""
 
+# サーバからの切断時に再接続を試みます
+retry = true
+
 # [log]
 # ログの出力先ディレクトリです
 log_dir = "."

--- a/config.go
+++ b/config.go
@@ -25,6 +25,8 @@ type Config struct {
 	HTTP2MaxReadFrameSize     uint32 `toml:"http2_max_read_frame_size"`
 	HTTP2IdleTimeout          uint32 `toml:"http2_idle_timeout"`
 
+	Retry bool `toml:"retry"`
+
 	ExporterIPAddress string `toml:"exporter_ip_address"`
 	ExporterPort      int    `toml:"exporter_port"`
 

--- a/config.go
+++ b/config.go
@@ -25,7 +25,7 @@ type Config struct {
 	HTTP2MaxReadFrameSize     uint32 `toml:"http2_max_read_frame_size"`
 	HTTP2IdleTimeout          uint32 `toml:"http2_idle_timeout"`
 
-	Retry bool `toml:"retry"`
+	Retry *bool `toml:"retry"`
 
 	ExporterIPAddress string `toml:"exporter_ip_address"`
 	ExporterPort      int    `toml:"exporter_port"`
@@ -85,6 +85,12 @@ func InitConfig(data []byte, config *Config) error {
 
 	if config.TimeToWaitForOpusPacketMs == 0 {
 		config.TimeToWaitForOpusPacketMs = DefaultTimeToWaitForOpusPacketMs
+	}
+
+	// 未指定の場合は true
+	if config.Retry == nil {
+		defaultRetry := true
+		config.Retry = &defaultRetry
 	}
 
 	// TODO(v): 初期値

--- a/handler.go
+++ b/handler.go
@@ -164,16 +164,26 @@ func (s *Server) createSpeechHandler(serviceType string, f serviceHandler) echo.
 							Send()
 						return echo.NewHTTPError(499)
 					} else if errors.Is(err, ErrServerDisconnected) {
-						// サーバから切断されたが再度接続できる可能性があるため、接続を試みる
-						retryCount += 1
+						if s.config.Retry {
+							// サーバから切断されたが再度接続できる可能性があるため、接続を試みる
+							retryCount += 1
 
-						zlog.Debug().
-							Err(err).
-							Str("CHANNEL-ID", h.SoraChannelID).
-							Str("CONNECTION-ID", h.SoraConnectionID).
-							Int("RETRY-COUNT", retryCount).
-							Send()
-						break
+							zlog.Debug().
+								Err(err).
+								Str("CHANNEL-ID", h.SoraChannelID).
+								Str("CONNECTION-ID", h.SoraConnectionID).
+								Int("RETRY-COUNT", retryCount).
+								Send()
+							break
+						} else {
+							// サーバから切断されたが再接続させない設定の場合
+							zlog.Error().
+								Err(err).
+								Str("CHANNEL-ID", h.SoraChannelID).
+								Str("CONNECTION-ID", h.SoraConnectionID).
+								Send()
+							return echo.NewHTTPError(http.StatusInternalServerError)
+						}
 					}
 
 					zlog.Error().

--- a/handler.go
+++ b/handler.go
@@ -164,7 +164,7 @@ func (s *Server) createSpeechHandler(serviceType string, f serviceHandler) echo.
 							Send()
 						return echo.NewHTTPError(499)
 					} else if errors.Is(err, ErrServerDisconnected) {
-						if s.config.Retry {
+						if *s.config.Retry {
 							// サーバから切断されたが再度接続できる可能性があるため、接続を試みる
 							retryCount += 1
 


### PR DESCRIPTION
サーバから切断された際に再接続処理を実行するかどうかの設定を追加しました

- 設定項目: retry
- デフォルト: 有効
- 無効の場合: 他の再接続対象外のエラーと同様に InternalServerError