### PR TITLE
stream 処理開始後のエラー処理の修正

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -93,6 +93,7 @@ func (s *Server) createSpeechHandler(serviceType string, onResultFunc func(conte
 			Msg("CONNECTED")
 
 		c.Response().Header().Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		// すぐにヘッダを送信したい場合はここで c.Response().Flush() を実行する
 
 		ctx := c.Request().Context()
 		// TODO: context.WithCancelCause(ctx) に変更する

--- a/handler.go
+++ b/handler.go
@@ -153,7 +153,7 @@ func (s *Server) createSpeechHandler(serviceType string, onResultFunc func(conte
 							Str("channel_id", h.SoraChannelID).
 							Str("connection_id", h.SoraConnectionID).
 							Send()
-						return echo.NewHTTPError(499)
+						return err
 					} else if errors.Is(err, ErrServerDisconnected) {
 						if *s.config.Retry {
 							// サーバから切断されたが再度接続できる可能性があるため、接続を試みる
@@ -173,7 +173,7 @@ func (s *Server) createSpeechHandler(serviceType string, onResultFunc func(conte
 								Str("channel_id", h.SoraChannelID).
 								Str("connection_id", h.SoraConnectionID).
 								Send()
-							return echo.NewHTTPError(http.StatusInternalServerError)
+							return err
 						}
 					}
 
@@ -182,8 +182,8 @@ func (s *Server) createSpeechHandler(serviceType string, onResultFunc func(conte
 						Str("channel_id", h.SoraChannelID).
 						Str("connection_id", h.SoraConnectionID).
 						Send()
-					// サーバから切断されたが再度の接続が期待できない場合、または、想定外のエラーの場合は InternalServerError
-					return echo.NewHTTPError(http.StatusInternalServerError)
+					// サーバから切断されたが再度の接続が期待できない場合
+					return err
 				}
 
 				// メッセージが空でない場合はクライアントに結果を送信する
@@ -194,7 +194,7 @@ func (s *Server) createSpeechHandler(serviceType string, onResultFunc func(conte
 							Str("channel_id", h.SoraChannelID).
 							Str("connection_id", h.SoraConnectionID).
 							Send()
-						return echo.NewHTTPError(http.StatusInternalServerError)
+						return err
 					}
 					c.Response().Flush()
 				}

--- a/test_handler_test.go
+++ b/test_handler_test.go
@@ -268,7 +268,7 @@ func TestSpeechHandler(t *testing.T) {
 		h := s.createSpeechHandler(serviceType, nil)
 		err = h(c)
 		if assert.Error(t, err) {
-			assert.Equal(t, http.StatusInternalServerError, err.(*echo.HTTPError).Code)
+			assert.Equal(t, "packet read error", err.Error())
 		}
 
 		pw.Close()
@@ -354,7 +354,7 @@ func TestSpeechHandler(t *testing.T) {
 		})
 		err := h(c)
 		if assert.Error(t, err) {
-			assert.Equal(t, http.StatusInternalServerError, err.(*echo.HTTPError).Code)
+			assert.Equal(t, "ON-RESULT-ERROR", err.Error())
 		}
 
 	})


### PR DESCRIPTION
stream 処理開始後に HTTPError を返すと、すでにクライアントに送信している status code は異なる値がログに出力されるため、エラーをそのまま返しています