### PR TITLE
Amazon Transcribe からの結果の Results[].ResultId をクライアントに返す機能と設定を追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@
 
 ## develop
 
+- [ADD] Amazon Transcribe からの結果の Results[].ResultId をクライアントに返す設定を追加する
+    - @Hexa
 
 ## 2024.2.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,8 @@
 
 ## develop
 
-- [ADD] Amazon Transcribe からの結果の Results[].ResultId をクライアントに返す設定を追加する
+- [ADD] Amazon Transcribe からの結果の Results[].ResultId をクライアントに返す aws_result_id 設定を追加する
+    - デフォルト値: false
     - @Hexa
 
 ## 2024.2.0

--- a/amazon_transcribe_handler.go
+++ b/amazon_transcribe_handler.go
@@ -161,7 +161,7 @@ func (h *AmazonTranscribeHandler) Handle(ctx context.Context, reader io.Reader) 
 							if at.Config.AwsResultChannelID {
 								result.WithChannelID(*res.ChannelId)
 							}
-							if at.Config.AwsResultResultID {
+							if at.Config.AwsResultID {
 								result.WithResultID(*res.ResultId)
 							}
 							for _, alt := range res.Alternatives {

--- a/amazon_transcribe_handler.go
+++ b/amazon_transcribe_handler.go
@@ -45,6 +45,7 @@ func NewAmazonTranscribeHandler(config Config, channelID, connectionID string, s
 type AwsResult struct {
 	ChannelID *string `json:"channel_id,omitempty"`
 	IsPartial *bool   `json:"is_partial,omitempty"`
+	ResultID  *string `json:"result_id,omitempty"`
 	TranscriptionResult
 }
 
@@ -63,6 +64,11 @@ func (ar *AwsResult) WithChannelID(channelID string) *AwsResult {
 
 func (ar *AwsResult) WithIsPartial(isPartial bool) *AwsResult {
 	ar.IsPartial = &isPartial
+	return ar
+}
+
+func (ar *AwsResult) WithResultID(resultID string) *AwsResult {
+	ar.ResultID = &resultID
 	return ar
 }
 
@@ -154,6 +160,9 @@ func (h *AmazonTranscribeHandler) Handle(ctx context.Context, reader io.Reader) 
 							}
 							if at.Config.AwsResultChannelID {
 								result.WithChannelID(*res.ChannelId)
+							}
+							if at.Config.AwsResultResultID {
+								result.WithResultID(*res.ResultId)
 							}
 							for _, alt := range res.Alternatives {
 								var message string

--- a/config.go
+++ b/config.go
@@ -87,6 +87,7 @@ type Config struct {
 	// 変換結果に含める項目の有無の指定
 	AwsResultChannelID bool `ini:"aws_result_channel_id"`
 	AwsResultIsPartial bool `ini:"aws_result_is_partial"`
+	AwsResultResultID  bool `ini:"aws_result_result_id"`
 
 	// Google Cloud Platform
 	GcpCredentialFile                      string   `ini:"gcp_credential_file"`

--- a/config.go
+++ b/config.go
@@ -87,7 +87,7 @@ type Config struct {
 	// 変換結果に含める項目の有無の指定
 	AwsResultChannelID bool `ini:"aws_result_channel_id"`
 	AwsResultIsPartial bool `ini:"aws_result_is_partial"`
-	AwsResultResultID  bool `ini:"aws_result_result_id"`
+	AwsResultID        bool `ini:"aws_result_id"`
 
 	// Google Cloud Platform
 	GcpCredentialFile                      string   `ini:"gcp_credential_file"`

--- a/config_example.ini
+++ b/config_example.ini
@@ -72,7 +72,7 @@ aws_result_channel_id = true
 # セグメントが完了していないかどうかです
 # aws_result_is_partial = true
 # 結果の識別子です
-# aws_result_result_id = true
+# aws_result_id = true
 
 # https://cloud.google.com/speech-to-text/docs/reference/rpc/google.cloud.speech.v1#streamingrecognitionconfig
 # https://cloud.google.com/speech-to-text/docs/reference/rpc/google.cloud.speech.v1#recognitionconfig

--- a/config_example.ini
+++ b/config_example.ini
@@ -67,8 +67,12 @@ aws_credential_file = ./credentials
 aws_profile = default
 
 # クライアントに送る変換結果の情報に付与する項目
+# 結果に関連付いているオーディオのチャネルです
 aws_result_channel_id = true
+# セグメントが完了していないかどうかです
 # aws_result_is_partial = true
+# 結果の識別子です
+# aws_result_result_id = true
 
 # https://cloud.google.com/speech-to-text/docs/reference/rpc/google.cloud.speech.v1#streamingrecognitionconfig
 # https://cloud.google.com/speech-to-text/docs/reference/rpc/google.cloud.speech.v1#recognitionconfig


### PR DESCRIPTION
This pull request includes changes to the `amazon_transcribe_handler.go`, `config.go`, `config_example.ini`, and `CHANGES.md` files. The changes primarily involve adding a new setting to return the `ResultId` from Amazon Transcribe results to the client. 

Key changes include:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R14-R15): Documented the addition of a new setting to return the `ResultId` from Amazon Transcribe results to the client.

Amazon Transcribe Handler changes:

* [`amazon_transcribe_handler.go`](diffhunk://#diff-80a00097f4667531152763b63d79bf825afac92654271ce6554444bb3d5efc1dR48): Added a `ResultID` field to the `AwsResult` struct and a new method `WithResultID` to set this field. [[1]](diffhunk://#diff-80a00097f4667531152763b63d79bf825afac92654271ce6554444bb3d5efc1dR48) [[2]](diffhunk://#diff-80a00097f4667531152763b63d79bf825afac92654271ce6554444bb3d5efc1dR70-R74)
* [`amazon_transcribe_handler.go`](diffhunk://#diff-80a00097f4667531152763b63d79bf825afac92654271ce6554444bb3d5efc1dR164-R166): Modified the `Handle` method to set the `ResultID` field of the `AwsResult` struct if the `AwsResultID` configuration is set.

Configuration changes:

* [`config.go`](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249R90): Added a new `AwsResultID` field to the `Config` struct.
* [`config_example.ini`](diffhunk://#diff-b85f5cca5558e6035d7f3fd0aa138ab1b719fa05e562a61c27ad75fe7a760d94R70-R75): Added a new `aws_result_id` configuration option.