### PR TITLE
audio streaming header に対応する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,12 @@
 
 ## develop
 
+- [ADD] audio streaming header に対応する
+  - @Hexa
+- [ADD] クライアントから送られてくるデータにヘッダーが付与されている場合に対応する audio_streaming_header 設定を追加する
+  - デフォルト値: false
+  - @Hexa
+
 ### misc
 
 ## 2024.3.0

--- a/config.go
+++ b/config.go
@@ -41,6 +41,8 @@ type Config struct {
 	ListenAddr string `ini:"listen_addr"`
 	ListenPort int    `ini:"listen_port"`
 
+	AudioStreamingHeader bool `ini:"audio_streaming_header"`
+
 	TLSFullchainFile    string `ini:"tls_fullchain_file"`
 	TLSPrivkeyFile      string `ini:"tls_privkey_file"`
 	TLSVerifyCacertPath string `ini:"tls_verify_cacert_path"` // クライアント認証用

--- a/config_example.ini
+++ b/config_example.ini
@@ -11,6 +11,9 @@ exporter_https = false
 exporter_listen_addr = 0.0.0.0
 exporter_listen_port = 48081
 
+# クライアントから受信する音声データにヘッダーが含まれている想定かどうかです
+audio_streaming_header = false
+
 # Suzu のサーバ証明書ファイルです
 # tls_fullchain_file =
 # Suzu の秘密鍵ファイルです

--- a/handler.go
+++ b/handler.go
@@ -2,6 +2,7 @@ package suzu
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -230,6 +231,73 @@ func (s *Server) createSpeechHandler(serviceType string, onResultFunc func(conte
 	}
 }
 
+func readPacketWithHeader(reader io.Reader) (io.Reader, error) {
+	r, w := io.Pipe()
+
+	go func() {
+		defer w.Close()
+
+		length := 0
+		payloadLength := 0
+		var payload []byte
+
+		for {
+			buf := make([]byte, 20+0xffff)
+			n, err := reader.Read(buf)
+			if err != nil {
+				// TODO: ログ出力
+				return
+			}
+
+			payload = append(payload, buf[:n]...)
+			length += n
+
+			if length > 20 {
+				// timestamp(64), sequence number(64), length(32)
+				h := payload[0:20]
+				p := payload[20:length]
+
+				payloadLength = int(binary.BigEndian.Uint32(h[16:20]))
+
+				if length == (20 + payloadLength) {
+					if _, err := w.Write(p); err != nil {
+						// TODO: ログ出力
+						return
+					}
+					payload = []byte{}
+					length = 0
+					continue
+				}
+
+				// payload が足りないのでさらに読み込む
+				if length < (20 + payloadLength) {
+					// 前の payload へ追加して次へ
+					payload = append(payload, p...)
+					continue
+				}
+
+				// 次の frame が含まれている場合
+				if length > (20 + payloadLength) {
+					payload = append(payload, p[:payloadLength]...)
+					if _, err := w.Write(payload); err != nil {
+						// TODO: ログ出力
+						return
+					}
+					// 次の payload 処理へ
+					payload = p[payloadLength:]
+					length = len(payload)
+					continue
+				}
+			} else {
+				// ヘッダー分に足りなければ次の読み込みへ
+				continue
+			}
+		}
+	}()
+
+	return r, nil
+}
+
 func opus2ogg(ctx context.Context, opusReader io.Reader, oggWriter io.Writer, sampleRate uint32, channelCount uint16, c Config) error {
 	o, err := NewWith(oggWriter, sampleRate, channelCount)
 	if err != nil {
@@ -249,13 +317,30 @@ func opus2ogg(ctx context.Context, opusReader io.Reader, oggWriter io.Writer, sa
 
 	for {
 		buf := make([]byte, FrameSize)
-		n, err := opusReader.Read(buf)
-		if err != nil {
-			if w, ok := oggWriter.(*io.PipeWriter); ok {
-				w.CloseWithError(err)
+		var n int
+		if c.AudioStreamingHeader {
+			r, err := readPacketWithHeader(opusReader)
+			if err != nil {
+				return err
 			}
-			return err
+
+			n, err = r.Read(buf)
+			if err != nil {
+				if w, ok := oggWriter.(*io.PipeWriter); ok {
+					w.CloseWithError(err)
+				}
+				return err
+			}
+		} else {
+			n, err = opusReader.Read(buf)
+			if err != nil {
+				if w, ok := oggWriter.(*io.PipeWriter); ok {
+					w.CloseWithError(err)
+				}
+				return err
+			}
 		}
+
 		if n > 0 {
 			opus := codecs.OpusPacket{}
 			_, err := opus.Unmarshal(buf[:n])

--- a/handler.go
+++ b/handler.go
@@ -235,8 +235,6 @@ func readPacketWithHeader(reader io.Reader) (io.Reader, error) {
 	r, w := io.Pipe()
 
 	go func() {
-		defer w.Close()
-
 		length := 0
 		payloadLength := 0
 		var payload []byte
@@ -245,7 +243,7 @@ func readPacketWithHeader(reader io.Reader) (io.Reader, error) {
 			buf := make([]byte, 20+0xffff)
 			n, err := reader.Read(buf)
 			if err != nil {
-				// TODO: ログ出力
+				w.CloseWithError(err)
 				return
 			}
 
@@ -261,7 +259,7 @@ func readPacketWithHeader(reader io.Reader) (io.Reader, error) {
 
 				if length == (20 + payloadLength) {
 					if _, err := w.Write(p); err != nil {
-						// TODO: ログ出力
+						w.CloseWithError(err)
 						return
 					}
 					payload = []byte{}
@@ -279,7 +277,7 @@ func readPacketWithHeader(reader io.Reader) (io.Reader, error) {
 				// 次の frame が含まれている場合
 				if length > (20 + payloadLength) {
 					if _, err := w.Write(p[:payloadLength]); err != nil {
-						// TODO: ログ出力
+						w.CloseWithError(err)
 						return
 					}
 					// 次の payload 処理へ
@@ -297,7 +295,7 @@ func readPacketWithHeader(reader io.Reader) (io.Reader, error) {
 							// すでに次の payload が全てある場合
 							if length == (20 + payloadLength) {
 								if _, err := w.Write(p); err != nil {
-									// TODO: ログ出力
+									w.CloseWithError(err)
 									return
 								}
 								payload = []byte{}
@@ -307,7 +305,7 @@ func readPacketWithHeader(reader io.Reader) (io.Reader, error) {
 
 							if length > (20 + payloadLength) {
 								if _, err := w.Write(p[:payloadLength]); err != nil {
-									// TODO: ログ出力
+									w.CloseWithError(err)
 									return
 								}
 

--- a/handler.go
+++ b/handler.go
@@ -278,8 +278,7 @@ func readPacketWithHeader(reader io.Reader) (io.Reader, error) {
 
 				// 次の frame が含まれている場合
 				if length > (20 + payloadLength) {
-					payload = append(payload, p[:payloadLength]...)
-					if _, err := w.Write(payload); err != nil {
+					if _, err := w.Write(p[:payloadLength]); err != nil {
 						// TODO: ログ出力
 						return
 					}

--- a/handler.go
+++ b/handler.go
@@ -361,8 +361,7 @@ func opus2ogg(ctx context.Context, opusReader io.Reader, oggWriter io.Writer, sa
 
 	for {
 		buf := make([]byte, FrameSize)
-		var n int
-		n, err = r.Read(buf)
+		n, err := r.Read(buf)
 		if err != nil {
 			if w, ok := oggWriter.(*io.PipeWriter); ok {
 				w.CloseWithError(err)


### PR DESCRIPTION
This pull request introduces support for handling audio streaming headers in the project. The main changes include adding a new configuration option, updating relevant configuration files, and implementing logic to process audio data with headers.

Key changes:

### Configuration Updates:
* Added `audio_streaming_header` setting to the `Config` struct in `config.go` to handle audio streaming headers.
* Updated `config_example.ini` to include the new `audio_streaming_header` setting with a default value of `false`.

### Documentation:
* Updated `CHANGES.md` to document the addition of the `audio_streaming_header` setting.

### Code Implementation:
* Added `readPacketWithHeader` function in `handler.go` to process audio data with headers.
* Modified the `opus2ogg` function in `handler.go` to use `readPacketWithHeader` when `audio_streaming_header` is enabled.

### Imports:
* Added the `encoding/binary` package import in `handler.go` to support the new header processing logic.
This pull request introduces a new feature to handle audio streaming headers in the application. The key changes include updating the configuration to support this feature, modifying the handler to process audio data with headers, and adding a new function to read packets with headers.

### Configuration Updates:
* [`config.go`](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249R44-R45): Added a new configuration option `AudioStreamingHeader` to handle audio streaming headers.
* [`config_example.ini`](diffhunk://#diff-b85f5cca5558e6035d7f3fd0aa138ab1b719fa05e562a61c27ad75fe7a760d94R14-R16): Updated the example configuration file to include the new `audio_streaming_header` option.

### Handler Modifications:
* [`handler.go`](diffhunk://#diff-0eb779b9e49d8e44b0f36923fdb8d87d5ee024f886eefc45deec4ec88380a087R234-R334): Added a new function `readPacketWithHeader` to process audio data with headers.
* [`handler.go`](diffhunk://#diff-0eb779b9e49d8e44b0f36923fdb8d87d5ee024f886eefc45deec4ec88380a087R352-R371): Updated the `opus2ogg` function to use the new `readPacketWithHeader` function if the `AudioStreamingHeader` configuration is enabled.

### Documentation:
* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R14-R19): Documented the addition of the audio streaming header feature and its configuration.