### PR TITLE
audio streaming header 関連処理の整理

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -16,7 +16,9 @@ import (
 )
 
 const (
-	FrameSize = 1024 * 10
+	FrameSize        = 1024 * 10
+	HeaderLength     = 20
+	MaxPayloadLength = 0xffff
 )
 
 var (
@@ -231,9 +233,7 @@ func (s *Server) createSpeechHandler(serviceType string, onResultFunc func(conte
 	}
 }
 
-const (
-	HeaderLength = 20
-)
+const ()
 
 func readPacketWithHeader(reader io.Reader) (io.Reader, error) {
 	r, w := io.Pipe()
@@ -244,7 +244,7 @@ func readPacketWithHeader(reader io.Reader) (io.Reader, error) {
 		var payload []byte
 
 		for {
-			buf := make([]byte, HeaderLength+0xffff)
+			buf := make([]byte, HeaderLength+MaxPayloadLength)
 			n, err := reader.Read(buf)
 			if err != nil {
 				w.CloseWithError(err)

--- a/handler.go
+++ b/handler.go
@@ -267,13 +267,6 @@ func readPacketWithHeader(reader io.Reader) (io.Reader, error) {
 					continue
 				}
 
-				// payload が足りないのでさらに読み込む
-				if length < (20 + payloadLength) {
-					// 前の payload へ追加して次へ
-					payload = append(payload, p...)
-					continue
-				}
-
 				// 次の frame が含まれている場合
 				if length > (20 + payloadLength) {
 					if _, err := w.Write(p[:payloadLength]); err != nil {
@@ -319,8 +312,6 @@ func readPacketWithHeader(reader io.Reader) (io.Reader, error) {
 							break
 						}
 					}
-
-					continue
 				}
 			} else {
 				// ヘッダー分に足りなければ次の読み込みへ


### PR DESCRIPTION
This pull request includes significant changes to the `handler.go` and `handler_test.go` files, primarily focusing on improving the packet reading mechanism and enhancing the test coverage. The changes involve refactoring the packet reading logic to use defined constants for header and payload lengths, and adding comprehensive tests for the new packet reading function.

### Refactoring and Improvements:
* [`handler.go`](diffhunk://#diff-0eb779b9e49d8e44b0f36923fdb8d87d5ee024f886eefc45deec4ec88380a087R20-R21): Introduced constants `HeaderLength` and `MaxPayloadLength` to replace hardcoded values in the packet reading logic, making the code more readable and maintainable. [[1]](diffhunk://#diff-0eb779b9e49d8e44b0f36923fdb8d87d5ee024f886eefc45deec4ec88380a087R20-R21) [[2]](diffhunk://#diff-0eb779b9e49d8e44b0f36923fdb8d87d5ee024f886eefc45deec4ec88380a087L243-R247) [[3]](diffhunk://#diff-0eb779b9e49d8e44b0f36923fdb8d87d5ee024f886eefc45deec4ec88380a087L253-L327)
* [`handler.go`](diffhunk://#diff-0eb779b9e49d8e44b0f36923fdb8d87d5ee024f886eefc45deec4ec88380a087L253-L327): Simplified the `readPacketWithHeader` function to handle packet reading more efficiently and clearly.

### Test Enhancements:
* [`handler_test.go`](diffhunk://#diff-39de3493ae7887b6c07ddf65fc59c005b3f2fccc9b06da022954597de5b12d7cR111-R313): Added a new test function `TestReadPacketWithHeader` to cover various scenarios for the `readPacketWithHeader` function, ensuring robust test coverage.
* [`handler_test.go`](diffhunk://#diff-39de3493ae7887b6c07ddf65fc59c005b3f2fccc9b06da022954597de5b12d7cL54-L88): Removed redundant test cases for audio streaming headers, as these are now covered by the new test function. [[1]](diffhunk://#diff-39de3493ae7887b6c07ddf65fc59c005b3f2fccc9b06da022954597de5b12d7cL54-L88) [[2]](diffhunk://#diff-39de3493ae7887b6c07ddf65fc59c005b3f2fccc9b06da022954597de5b12d7cL107-L109) [[3]](diffhunk://#diff-39de3493ae7887b6c07ddf65fc59c005b3f2fccc9b06da022954597de5b12d7cL130-L132)