### PR TITLE
aws の再接続条件に InternalFailureException を追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@
 
 ## develop
 
+- [CHANGE] aws の再接続条件の exception に InternalFailureException を追加する
+  - @Hexa
+
 ### misc
 
 ## 2024.5.1

--- a/amazon_transcribe_handler.go
+++ b/amazon_transcribe_handler.go
@@ -193,7 +193,8 @@ func (h *AmazonTranscribeHandler) Handle(ctx context.Context, reader io.Reader) 
 
 			// 復帰が不可能なエラー以外は再接続を試みる
 			switch err.(type) {
-			case *transcribestreamingservice.LimitExceededException:
+			case *transcribestreamingservice.LimitExceededException,
+				*transcribestreamingservice.InternalFailureException:
 				// リトライしない設定の場合、または、max_retry を超えた場合はクライアントにエラーを返し、再度接続するかはクライアント側で判断する
 				if (at.Config.MaxRetry < 1) || (at.Config.MaxRetry <= h.GetRetryCount()) {
 					if err := encoder.Encode(NewSuzuErrorResponse(err)); err != nil {


### PR DESCRIPTION
This pull request includes changes to add the `InternalFailureException` to the reconnection conditions for AWS in the `amazon_transcribe_handler.go` file and updates the `CHANGES.md` file to reflect this modification. The most important changes are:

* Changes to reconnection conditions:
  * [`amazon_transcribe_handler.go`](diffhunk://#diff-80a00097f4667531152763b63d79bf825afac92654271ce6554444bb3d5efc1dL196-R197): Added `InternalFailureException` to the list of exceptions that trigger a reconnection attempt in the `Handle` function.

* Documentation updates:
  * [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R14-R16): Updated to include the addition of `InternalFailureException` to the AWS reconnection conditions.