### PR TITLE
クライアントに返す結果の評価に Confidence, StartTime, EndTime を使用できる仕組みを追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,10 +11,12 @@
 
 ## develop
 
-- [ADD] 採用する結果の信頼スコアの最小値を指定する minimum_confidence_score を追加する（aws のみ有効）
+- [ADD] 採用する結果の信頼スコアの最小値を指定する minimum_confidence_score を追加する
+  - Amazon Transcribe のみ有効
   - デフォルト値: 0（信頼スコアを無視する）
   - @Hexa
-- [ADD] 採用する結果の最小発話期間（秒）を指定する minimum_transcribed_time を追加する（aws のみ有効）
+- [ADD] 採用する結果の最小発話期間（秒）を指定する minimum_transcribed_time を追加する
+  - Amazon Transcribe のみ有効
   - デフォルト値: 0（最小発話期間を無視する）
   - @Hexa
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,13 @@
 
 ## develop
 
+- [ADD] 採用する結果の信頼スコアの最小値を指定する minimum_confidence_score を追加する
+  - デフォルト値: 0（信頼スコアを無視する）
+  - @Hexa
+- [ADD] 採用する結果の最小発話期間（秒）を指定する minimum_transcribed_time を追加する
+  - デフォルト値: 0（最小発話期間を無視する）
+  - @Hexa
+
 ### misc
 
 ## 2024.7.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,10 +11,10 @@
 
 ## develop
 
-- [ADD] 採用する結果の信頼スコアの最小値を指定する minimum_confidence_score を追加する
+- [ADD] 採用する結果の信頼スコアの最小値を指定する minimum_confidence_score を追加する（aws のみ有効）
   - デフォルト値: 0（信頼スコアを無視する）
   - @Hexa
-- [ADD] 採用する結果の最小発話期間（秒）を指定する minimum_transcribed_time を追加する
+- [ADD] 採用する結果の最小発話期間（秒）を指定する minimum_transcribed_time を追加する（aws のみ有効）
   - デフォルト値: 0（最小発話期間を無視する）
   - @Hexa
 

--- a/amazon_transcribe_handler.go
+++ b/amazon_transcribe_handler.go
@@ -200,7 +200,7 @@ func (h *AmazonTranscribeHandler) Handle(ctx context.Context, opusCh chan opusCh
 
 func buildMessage(config Config, alt transcribestreamingservice.Alternative, isPartial bool) (string, bool) {
 	minimumConfidenceScore := config.MinimumConfidenceScore
-	minimumTranscribedTimeMs := config.MinimumTranscribedTimeMs
+	minimumTranscribedTime := config.MinimumTranscribedTime
 
 	var message string
 	if minimumConfidenceScore > 0 {
@@ -222,7 +222,7 @@ func buildMessage(config Config, alt transcribestreamingservice.Alternative, isP
 
 				if (item.StartTime != nil) && (item.EndTime != nil) {
 					if (*item.EndTime - *item.StartTime) > 0 {
-						if (*item.EndTime - *item.StartTime) < minimumTranscribedTimeMs {
+						if (*item.EndTime - *item.StartTime) < minimumTranscribedTime {
 							// 発話時間が短い場合は次へ
 							continue
 						}

--- a/amazon_transcribe_handler.go
+++ b/amazon_transcribe_handler.go
@@ -153,49 +153,9 @@ func (h *AmazonTranscribeHandler) Handle(ctx context.Context, opusCh chan opusCh
 								result.WithResultID(*res.ResultId)
 							}
 
-							minimumConfidenceScore := at.Config.MinimumConfidenceScore
-							minimumTranscribedTimeMs := at.Config.MinimumTranscribedTimeMs
-
 							for _, alt := range res.Alternatives {
-								items := alt.Items
-
-								var message string
-								if minimumConfidenceScore > 0 {
-									if *res.IsPartial {
-										// IsPartial: true の場合は Transcript をそのまま使用する
-										if alt.Transcript != nil {
-											message = *alt.Transcript
-										}
-									} else {
-										for _, item := range items {
-											if item.Confidence != nil {
-												if *item.Confidence < minimumConfidenceScore {
-													// 信頼スコアが低い場合は次へ
-													continue
-												}
-											}
-
-											if (item.StartTime != nil) && (item.EndTime != nil) {
-												if (*item.EndTime - *item.StartTime) > 0 {
-													if (*item.EndTime - *item.StartTime) < minimumTranscribedTimeMs {
-														// 発話時間が短い場合は次へ
-														continue
-													}
-												}
-											}
-
-											message += *item.Content
-										}
-									}
-								} else {
-									// minimumConfidenceScore が設定されていない（0）場合は Transcript をそのまま使用する
-									if alt.Transcript != nil {
-										message = *alt.Transcript
-									}
-								}
-
-								// メッセージが空の場合は次へ
-								if message == "" {
+								message, ok := buildMessage(at.Config, *alt, *res.IsPartial)
+								if !ok {
 									continue
 								}
 
@@ -236,4 +196,54 @@ func (h *AmazonTranscribeHandler) Handle(ctx context.Context, opusCh chan opusCh
 	}()
 
 	return r, nil
+}
+
+func buildMessage(config Config, alt transcribestreamingservice.Alternative, isPartial bool) (string, bool) {
+	minimumConfidenceScore := config.MinimumConfidenceScore
+	minimumTranscribedTimeMs := config.MinimumTranscribedTimeMs
+
+	var message string
+	if minimumConfidenceScore > 0 {
+		if isPartial {
+			// IsPartial: true の場合は Transcript をそのまま使用する
+			if alt.Transcript != nil {
+				message = *alt.Transcript
+			}
+		} else {
+			items := alt.Items
+
+			for _, item := range items {
+				if item.Confidence != nil {
+					if *item.Confidence < minimumConfidenceScore {
+						// 信頼スコアが低い場合は次へ
+						continue
+					}
+				}
+
+				if (item.StartTime != nil) && (item.EndTime != nil) {
+					if (*item.EndTime - *item.StartTime) > 0 {
+						if (*item.EndTime - *item.StartTime) < minimumTranscribedTimeMs {
+							// 発話時間が短い場合は次へ
+							continue
+						}
+					}
+				}
+
+				message += *item.Content
+			}
+		}
+	} else {
+		// minimumConfidenceScore が設定されていない（0）場合は Transcript をそのまま使用する
+		if alt.Transcript != nil {
+			message = *alt.Transcript
+		}
+	}
+
+	// メッセージが空の場合は次へ
+	if message == "" {
+		return message, false
+	}
+
+	return message, true
+
 }

--- a/config.go
+++ b/config.go
@@ -79,8 +79,8 @@ type Config struct {
 	// aws の場合は IsPartial が false, gcp の場合は IsFinal が true の場合にのみ結果を返す指定
 	FinalResultOnly bool `ini:"final_result_only"`
 
-	MinimumConfidenceScore   float64 `ini:"minimum_confidence_score"`
-	MinimumTranscribedTimeMs float64 `ini:"minimum_transcribed_time_ms"`
+	MinimumConfidenceScore float64 `ini:"minimum_confidence_score"`
+	MinimumTranscribedTime float64 `ini:"minimum_transcribed_time"`
 
 	// Amazon Web Services
 	AwsCredentialFile                    string `ini:"aws_credential_file"`

--- a/config.go
+++ b/config.go
@@ -79,6 +79,9 @@ type Config struct {
 	// aws の場合は IsPartial が false, gcp の場合は IsFinal が true の場合にのみ結果を返す指定
 	FinalResultOnly bool `ini:"final_result_only"`
 
+	MinimumConfidenceScore   float64 `ini:"minimum_confidence_score"`
+	MinimumTranscribedTimeMs float64 `ini:"minimum_transcribed_time_ms"`
+
 	// Amazon Web Services
 	AwsCredentialFile                    string `ini:"aws_credential_file"`
 	AwsProfile                           string `ini:"aws_profile"`

--- a/config_example.ini
+++ b/config_example.ini
@@ -55,6 +55,12 @@ retry_interval_ms = 100
 # aws の場合は IsPartial が false, gcp の場合は IsFinal が true の場合の最終的な結果のみを返す指定
 final_result_only = true
 
+# 採用する結果の信頼スコアの最小値です
+# minimum_confidence_score = 0.0
+
+# 採用する結果の最小発話期間（秒）です
+# minimum_transcribed_time = 0.0
+
 # [aws]
 aws_region = ap-northeast-1
 # Partial-result stabilization の有効化です

--- a/config_example.ini
+++ b/config_example.ini
@@ -55,10 +55,10 @@ retry_interval_ms = 100
 # aws の場合は IsPartial が false, gcp の場合は IsFinal が true の場合の最終的な結果のみを返す指定
 final_result_only = true
 
-# 採用する結果の信頼スコアの最小値です
+# 採用する結果の信頼スコアの最小値です（aws 指定時のみ有効）
 # minimum_confidence_score = 0.0
 
-# 採用する結果の最小発話期間（秒）です
+# 採用する結果の最小発話期間（秒）です（aws 指定時のみ有効）
 # minimum_transcribed_time = 0.0
 
 # [aws]


### PR DESCRIPTION
This pull request adds new configuration options and refactors the handling of transcription results in the `AmazonTranscribeHandler`. The most important changes include the addition of `minimum_confidence_score` and `minimum_transcribed_time` settings, as well as the introduction of a new function to build messages based on these settings.

New configuration options:

* [`config.go`](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249R82-R84): Added `MinimumConfidenceScore` and `MinimumTranscribedTime` fields to the `Config` struct.
* [`config_example.ini`](diffhunk://#diff-b85f5cca5558e6035d7f3fd0aa138ab1b719fa05e562a61c27ad75fe7a760d94R58-R63): Added example settings for `minimum_confidence_score` and `minimum_transcribed_time`.

Refactoring of transcription result handling:

* [`amazon_transcribe_handler.go`](diffhunk://#diff-80a00097f4667531152763b63d79bf825afac92654271ce6554444bb3d5efc1dR200-R249): Introduced the `buildMessage` function to handle the creation of messages based on `minimum_confidence_score` and `minimum_transcribed_time` settings.
* [`amazon_transcribe_handler.go`](diffhunk://#diff-80a00097f4667531152763b63d79bf825afac92654271ce6554444bb3d5efc1dR155-R161): Updated the `Handle` method to use the new `buildMessage` function.

Documentation updates:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R14-R20): Documented the addition of `minimum_confidence_score` and `minimum_transcribed_time` settings.