### PR TITLE
ドキュメントのタイポを修正

### DIFF
--- a/doc/USE.md
+++ b/doc/USE.md
@@ -72,4 +72,4 @@ GCP Speech-to-Text を利用するに当たっての注意事項は [GCP.md](GCP
 ### /dump
 
 この URL を Sora の audio_streaming_url を指定すると、
-音声ストリミーングに流れてくる音声データを JSON 形式でダンプします。
+音声ストリーミングに流れてくる音声データを JSON 形式でダンプします。


### PR DESCRIPTION
タイポを修正。

---
This pull request includes a minor correction to the `doc/USE.md` file. The change fixes a typo in the description of the `/dump` URL.

* [`doc/USE.md`](diffhunk://#diff-abe0b25fa6145a39359775f813d4adac9c0f6f09af0418ce61950ced2dcceebbL75-R75): Corrected the typo "ストリミーング" to "ストリーミング" in the `/dump` URL description.