### PR TITLE
make init は不要になっているので削除する

### DIFF
--- a/doc/DEV.md
+++ b/doc/DEV.md
@@ -5,7 +5,6 @@
 初回だけ make init と設定を cp する必要があります。
 
 ```console
-$ make init
 $ cp config_example.ini config.ini
 ```
 


### PR DESCRIPTION
doc/DEV.md の初回説明から、make init を削除しました。
過去の Makefile では必要でしたが、現在は make init は不要であるためです。

---

This pull request includes a small change to the `doc/DEV.md` file. The change removes the `make init` command from the documentation.

* [`doc/DEV.md`](diffhunk://#diff-d22e231fc0879d353b3fd835f4437613b4c3a14aa8e9df1b73567913b21de82cL8): Removed the `make init` command from the documentation.