### PR TITLE
minimumTranscribedTime と minimumConfidenceScore の両方が無効に設定されている場合はフィルタリングしない結果を返す

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@
 
 ## develop
 
+- [CHANGE] Amazon Transcribe 向けの minimum_confidence_score と minimum_transcribed_time が両方ともに無効（0）に設定されていた場合は、フィルタリングしない結果を返すように変更する
+  - @Hexa
+
 ### misc
 
 - [CHANGE] GitHub Actions の ubuntu-latest を ubuntu-24.04 に変更する

--- a/amazon_transcribe_handler.go
+++ b/amazon_transcribe_handler.go
@@ -254,6 +254,15 @@ func contentFilterByConfidenceScore(config Config, item transcribestreamingservi
 
 func buildMessage(config Config, alt transcribestreamingservice.Alternative, isPartial bool) (string, bool) {
 	var message string
+
+	minimumTranscribedTime := config.MinimumTranscribedTime
+	minimumConfidenceScore := config.MinimumConfidenceScore
+
+	// 両方無効の場合には全てのメッセージを返す
+	if (minimumTranscribedTime <= 0) && (minimumConfidenceScore <= 0) {
+		return *alt.Transcript, true
+	}
+
 	items := alt.Items
 
 	includePronunciation := false

--- a/amazon_transcribe_handler_test.go
+++ b/amazon_transcribe_handler_test.go
@@ -20,6 +20,58 @@ func TestBuildMessage(t *testing.T) {
 		Ok      bool
 	}
 
+	t.Run("default", func(t *testing.T) {
+		testCases := []struct {
+			Name   string
+			Config Config
+			Input  Input
+			Expect Expect
+		}{
+			{
+				Name: "minimumTranscribedTime == 0 && minimumConfidenceScore == 0",
+				Config: Config{
+					MinimumTranscribedTime: 0,
+					MinimumConfidenceScore: 0,
+				},
+				Input: Input{
+					Alt: transcribestreamingservice.Alternative{
+						Transcript: aws.String("filter is disabled"),
+						Items: []*transcribestreamingservice.Item{
+							{
+								StartTime:  aws.Float64(0),
+								EndTime:    aws.Float64(1),
+								Confidence: aws.Float64(1),
+								Content:    aws.String("test"),
+								Type:       aws.String(transcribestreamingservice.ItemTypePronunciation),
+							},
+							{
+								StartTime:  aws.Float64(0),
+								EndTime:    aws.Float64(1),
+								Confidence: aws.Float64(1),
+								Content:    aws.String("data"),
+								Type:       aws.String(transcribestreamingservice.ItemTypePronunciation),
+							},
+						},
+					},
+					IsPartial: false,
+				},
+				Expect: Expect{
+					Message: "filter is disabled",
+					Ok:      true,
+				},
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.Name, func(t *testing.T) {
+				actual, ok := buildMessage(tc.Config, tc.Input.Alt, tc.Input.IsPartial)
+				assert.Equal(t, tc.Expect.Ok, ok)
+				assert.Equal(t, tc.Expect.Message, actual)
+			})
+		}
+
+	})
+
 	t.Run("minimumTranscribedTime", func(t *testing.T) {
 		testCases := []struct {
 			Name   string
@@ -31,21 +83,24 @@ func TestBuildMessage(t *testing.T) {
 				Name: "minimumTranscribedTime is 0",
 				Config: Config{
 					MinimumTranscribedTime: 0,
+					MinimumConfidenceScore: 0.1,
 				},
 				Input: Input{
 					Alt: transcribestreamingservice.Alternative{
 						Items: []*transcribestreamingservice.Item{
 							{
-								StartTime: aws.Float64(0),
-								EndTime:   aws.Float64(0),
-								Content:   aws.String("test"),
-								Type:      aws.String(transcribestreamingservice.ItemTypePronunciation),
+								StartTime:  aws.Float64(0),
+								EndTime:    aws.Float64(0),
+								Confidence: aws.Float64(1),
+								Content:    aws.String("test"),
+								Type:       aws.String(transcribestreamingservice.ItemTypePronunciation),
 							},
 							{
-								StartTime: aws.Float64(0),
-								EndTime:   aws.Float64(0),
-								Content:   aws.String("data"),
-								Type:      aws.String(transcribestreamingservice.ItemTypePronunciation),
+								StartTime:  aws.Float64(0),
+								EndTime:    aws.Float64(0),
+								Confidence: aws.Float64(1),
+								Content:    aws.String("data"),
+								Type:       aws.String(transcribestreamingservice.ItemTypePronunciation),
 							},
 						},
 					},
@@ -223,6 +278,7 @@ func TestBuildMessage(t *testing.T) {
 				{
 					Name: "minimumConfidenceScore is 0",
 					Config: Config{
+						MinimumTranscribedTime: 0.01,
 						MinimumConfidenceScore: 0,
 					},
 					Input: Input{
@@ -231,14 +287,14 @@ func TestBuildMessage(t *testing.T) {
 								{
 									Confidence: aws.Float64(0),
 									StartTime:  aws.Float64(0),
-									EndTime:    aws.Float64(0),
+									EndTime:    aws.Float64(1),
 									Content:    aws.String("test"),
 									Type:       aws.String(transcribestreamingservice.ItemTypePronunciation),
 								},
 								{
 									Confidence: aws.Float64(0),
 									StartTime:  aws.Float64(0),
-									EndTime:    aws.Float64(0),
+									EndTime:    aws.Float64(1),
 									Content:    aws.String("data"),
 									Type:       aws.String(transcribestreamingservice.ItemTypePronunciation),
 								},
@@ -429,6 +485,7 @@ func TestBuildMessage(t *testing.T) {
 				{
 					Name: "minimumConfidenceScore is 0",
 					Config: Config{
+						MinimumTranscribedTime: 0.01,
 						MinimumConfidenceScore: 0,
 					},
 					Input: Input{
@@ -437,14 +494,14 @@ func TestBuildMessage(t *testing.T) {
 								{
 									Confidence: aws.Float64(0),
 									StartTime:  aws.Float64(0),
-									EndTime:    aws.Float64(0),
+									EndTime:    aws.Float64(1),
 									Content:    aws.String("test"),
 									Type:       aws.String(transcribestreamingservice.ItemTypePronunciation),
 								},
 								{
 									Confidence: aws.Float64(0),
 									StartTime:  aws.Float64(0),
-									EndTime:    aws.Float64(0),
+									EndTime:    aws.Float64(1),
 									Content:    aws.String("data"),
 									Type:       aws.String(transcribestreamingservice.ItemTypePronunciation),
 								},

--- a/config_example.ini
+++ b/config_example.ini
@@ -55,11 +55,16 @@ retry_interval_ms = 100
 # aws の場合は IsPartial が false, gcp の場合は IsFinal が true の場合の最終的な結果のみを返す指定
 final_result_only = true
 
+
 # 採用する結果の信頼スコアの最小値です（aws 指定時のみ有効）
+# minimum_confidence_score が 0.0 の場合は信頼スコアによるフィルタリングは無効です
 # minimum_confidence_score = 0.0
 
 # 採用する結果の最小発話期間（秒）です（aws 指定時のみ有効）
+# minimum_transcribed_time が 0.0 の場合は発話期間によるフィルタリングは無効です
 # minimum_transcribed_time = 0.0
+
+# minimum_confidence_score と minimum_transcribed_time の両方が無効の場合はフィルタリングしません
 
 # [aws]
 aws_region = ap-northeast-1


### PR DESCRIPTION
This pull request includes changes to the Amazon Transcribe handler to modify the behavior when both `minimum_confidence_score` and `minimum_transcribed_time` are set to zero. Additionally, it updates related test cases to ensure proper functionality.

Changes to Amazon Transcribe handler:

* [`amazon_transcribe_handler.go`](diffhunk://#diff-80a00097f4667531152763b63d79bf825afac92654271ce6554444bb3d5efc1dR257-R265): Updated the `buildMessage` function to return all messages when both `minimum_confidence_score` and `minimum_transcribed_time` are set to zero.

Updates to test cases:

* [`amazon_transcribe_handler_test.go`](diffhunk://#diff-bee19cda26618699e534f163cf6bf4bb51471b24ed4627665b7c00a17ea60aeaR23-R74): Added a new test case to verify the behavior when both `minimum_confidence_score` and `minimum_transcribed_time` are set to zero.
* [`amazon_transcribe_handler_test.go`](diffhunk://#diff-bee19cda26618699e534f163cf6bf4bb51471b24ed4627665b7c00a17ea60aeaR86-R101): Updated existing test cases to include `minimum_confidence_score` and `minimum_transcribed_time` configurations. [[1]](diffhunk://#diff-bee19cda26618699e534f163cf6bf4bb51471b24ed4627665b7c00a17ea60aeaR86-R101) [[2]](diffhunk://#diff-bee19cda26618699e534f163cf6bf4bb51471b24ed4627665b7c00a17ea60aeaR281) [[3]](diffhunk://#diff-bee19cda26618699e534f163cf6bf4bb51471b24ed4627665b7c00a17ea60aeaL234-R297) [[4]](diffhunk://#diff-bee19cda26618699e534f163cf6bf4bb51471b24ed4627665b7c00a17ea60aeaR488) [[5]](diffhunk://#diff-bee19cda26618699e534f163cf6bf4bb51471b24ed4627665b7c00a17ea60aeaL440-R504)

Documentation update:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R14-R16): Documented the change in behavior for Amazon Transcribe when both `minimum_confidence_score` and `minimum_transcribed_time` are set to zero.