### PR TITLE
音声データを Ogg ファイルで出力できる機能の追加

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@
 ## develop
 
 - [ADD] 受信した音声データを Ogg ファイルで保存するかを指定する enable_ogg_file_output を追加する
+  - 保存するファイル名は、sora-session-id ヘッダーと sora-connection-id　ヘッダーの値を使用して作成する
+    - ${sora-session-id}-${sora-connection-id}.ogg
   - デフォルト値: false
   - @Hexa
 - [ADD] 受信した音声データを Ogg ファイルで保存する場合の保存先ディレクトリを指定する ogg_dir を追加する

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@
 ## develop
 
 - [ADD] 受信した音声データを Ogg ファイルで保存するかを指定する enable_ogg_file_output を追加する
-  - 保存するファイル名は、sora-session-id ヘッダーと sora-connection-id　ヘッダーの値を使用して作成する
+  - 保存するファイル名は、sora-session-id ヘッダーと sora-connection-id ヘッダーの値を使用して作成する
     - ${sora-session-id}-${sora-connection-id}.ogg
   - デフォルト値: false
   - @Hexa

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,13 @@
 
 ## develop
 
+- [ADD] 受信した音声データを Ogg ファイルで保存するかを指定する enable_ogg_file_output を追加する
+  - デフォルト値: false
+  - @Hexa
+- [ADD] 受信した音声データを Ogg ファイルで保存する場合の保存先ディレクトリを指定する ogg_dir を追加する
+  - デフォルト値: .
+  - @Hexa
+
 ### misc
 
 - [CHANGE] GitHub Actions の ubuntu-latest を ubuntu-24.04 に変更する

--- a/amazon_transcribe_handler.go
+++ b/amazon_transcribe_handler.go
@@ -96,10 +96,13 @@ func (h *AmazonTranscribeHandler) ResetRetryCount() int {
 	return h.RetryCount
 }
 
-func (h *AmazonTranscribeHandler) Handle(ctx context.Context, opusCh chan opusChannel) (*io.PipeReader, error) {
+func (h *AmazonTranscribeHandler) Handle(ctx context.Context, opusCh chan opusChannel, header soraHeader) (*io.PipeReader, error) {
 	at := NewAmazonTranscribe(h.Config, h.LanguageCode, int64(h.SampleRate), int64(h.ChannelCount))
 
-	packetReader := opus2ogg(ctx, opusCh, h.SampleRate, h.ChannelCount, h.Config)
+	packetReader, err := opus2ogg(ctx, opusCh, h.SampleRate, h.ChannelCount, h.Config, header)
+	if err != nil {
+		return nil, err
+	}
 
 	stream, err := at.Start(ctx, packetReader)
 	if err != nil {

--- a/config.go
+++ b/config.go
@@ -65,6 +65,9 @@ type Config struct {
 	SampleRate   int `ini:"audio_sample_rate"`
 	ChannelCount int `ini:"audio_channel_count"`
 
+	EnableOggFileOutput bool   `ini:"enable_ogg_file_output"`
+	OggDir              string `ini:"ogg_dir"`
+
 	DumpFile string `ini:"dump_file"`
 
 	LogDir              string `ini:"log_dir"`
@@ -172,6 +175,10 @@ func setDefaultsConfig(config *Config) {
 
 	if config.RetryIntervalMs == 0 {
 		config.RetryIntervalMs = DefaultRetryIntervalMs
+	}
+
+	if config.OggDir == "" {
+		config.OggDir = "."
 	}
 }
 

--- a/config_example.ini
+++ b/config_example.ini
@@ -55,6 +55,10 @@ retry_interval_ms = 100
 # aws の場合は IsPartial が false, gcp の場合は IsFinal が true の場合の最終的な結果のみを返す指定
 final_result_only = true
 
+# 受信した音声データを Ogg ファイルで保存するかどうかです
+enable_ogg_file_output = false
+# Ogg ファイルの保存先ディレクトリです
+ogg_dir = "."
 
 # 採用する結果の信頼スコアの最小値です（aws 指定時のみ有効）
 # minimum_confidence_score が 0.0 の場合は信頼スコアによるフィルタリングは無効です

--- a/handler.go
+++ b/handler.go
@@ -44,7 +44,7 @@ func NewSuzuErrorResponse(err error) TranscriptionResult {
 }
 
 type soraHeader struct {
-	SoraChannelID string `header:"Sora-Channel-Id"`
+	SoraChannelID string `header:"sora-channel-id"`
 	SoraSessionID string `header:"sora-session-id"`
 	// SoraClientID        string `header:"sora-client-id"`
 	SoraConnectionID string `header:"sora-connection-id"`

--- a/handler.go
+++ b/handler.go
@@ -467,7 +467,6 @@ func opus2ogg(ctx context.Context, opusCh chan opusChannel, sampleRate uint32, c
 	oggReader, oggWriter := io.Pipe()
 
 	writers := []io.Writer{}
-	writers = append(writers, oggWriter)
 
 	var f *os.File
 	if c.EnableOggFileOutput {
@@ -481,6 +480,7 @@ func opus2ogg(ctx context.Context, opusCh chan opusChannel, sampleRate uint32, c
 		}
 		writers = append(writers, f)
 	}
+	writers = append(writers, oggWriter)
 
 	multiWriter := io.MultiWriter(writers...)
 

--- a/handler.go
+++ b/handler.go
@@ -470,7 +470,7 @@ func opus2ogg(ctx context.Context, opusCh chan opusChannel, sampleRate uint32, c
 
 	var f *os.File
 	if c.EnableOggFileOutput {
-		fileName := fmt.Sprintf("%s_%s.ogg", header.SoraSessionID, header.SoraConnectionID)
+		fileName := fmt.Sprintf("%s-%s.ogg", header.SoraSessionID, header.SoraConnectionID)
 		filePath := path.Join(c.OggDir, fileName)
 
 		var err error

--- a/handler.go
+++ b/handler.go
@@ -469,10 +469,13 @@ func opus2ogg(ctx context.Context, opusCh chan opusChannel, sampleRate uint32, c
 	writers := []io.Writer{}
 	writers = append(writers, oggWriter)
 
+	var f *os.File
 	if c.EnableOggFileOutput {
 		fileName := fmt.Sprintf("%s_%s.ogg", header.SoraSessionID, header.SoraConnectionID)
 		filePath := path.Join(c.OggDir, fileName)
-		f, err := os.Create(filePath)
+
+		var err error
+		f, err = os.Create(filePath)
 		if err != nil {
 			return nil, err
 		}
@@ -488,6 +491,10 @@ func opus2ogg(ctx context.Context, opusCh chan opusChannel, sampleRate uint32, c
 			return
 		}
 		defer o.Close()
+
+		if c.EnableOggFileOutput {
+			o.fd = f
+		}
 
 		for {
 			select {

--- a/handler_test.go
+++ b/handler_test.go
@@ -364,11 +364,7 @@ func TestOggFileWriting(t *testing.T) {
 
 		buf := make([]byte, 4)
 		n, err := f.Read(buf)
-		if err != nil {
-			if !errors.Is(err, io.EOF) {
-				t.Fatal(err)
-			}
-		}
+		assert.NoError(t, err)
 		assert.Equal(t, []byte(`OggS`), buf[:n])
 	})
 

--- a/handler_test.go
+++ b/handler_test.go
@@ -347,10 +347,29 @@ func TestOggFileWriting(t *testing.T) {
 		}
 		defer reader.Close()
 
+		// ファイルへの書き込み待ち
+		time.Sleep(100 * time.Millisecond)
+
 		filename := fmt.Sprintf("%s-%s.ogg", header.SoraSessionID, header.SoraConnectionID)
 		filePath := filepath.Join(oggDir, filename)
 		_, err = os.Stat(filePath)
 		assert.NoError(t, err)
+
+		// Ogg ファイルのヘッダーを確認
+		f, err := os.Open(filePath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer f.Close()
+
+		buf := make([]byte, 4)
+		n, err := f.Read(buf)
+		if err != nil {
+			if !errors.Is(err, io.EOF) {
+				t.Fatal(err)
+			}
+		}
+		assert.Equal(t, []byte(`OggS`), buf[:n])
 	})
 
 	t.Run("disable_ogg_file_output", func(t *testing.T) {

--- a/packet_dump_handler.go
+++ b/packet_dump_handler.go
@@ -67,7 +67,7 @@ func (h *PacketDumpHandler) ResetRetryCount() int {
 	return h.RetryCount
 }
 
-func (h *PacketDumpHandler) Handle(ctx context.Context, opusCh chan opusChannel) (*io.PipeReader, error) {
+func (h *PacketDumpHandler) Handle(ctx context.Context, opusCh chan opusChannel, header soraHeader) (*io.PipeReader, error) {
 	c := h.Config
 	filename := c.DumpFile
 	channelID := h.ChannelID

--- a/service_handler.go
+++ b/service_handler.go
@@ -15,7 +15,7 @@ var (
 )
 
 type serviceHandlerInterface interface {
-	Handle(context.Context, chan opusChannel) (*io.PipeReader, error)
+	Handle(context.Context, chan opusChannel, soraHeader) (*io.PipeReader, error)
 	UpdateRetryCount() int
 	GetRetryCount() int
 	ResetRetryCount() int

--- a/speech_to_text_handler.go
+++ b/speech_to_text_handler.go
@@ -91,10 +91,13 @@ func (h *SpeechToTextHandler) ResetRetryCount() int {
 	return h.RetryCount
 }
 
-func (h *SpeechToTextHandler) Handle(ctx context.Context, opusCh chan opusChannel) (*io.PipeReader, error) {
+func (h *SpeechToTextHandler) Handle(ctx context.Context, opusCh chan opusChannel, header soraHeader) (*io.PipeReader, error) {
 	stt := NewSpeechToText(h.Config, h.LanguageCode, int32(h.SampleRate), int32(h.ChannelCount))
 
-	packetReader := opus2ogg(ctx, opusCh, h.SampleRate, h.ChannelCount, h.Config)
+	packetReader, err := opus2ogg(ctx, opusCh, h.SampleRate, h.ChannelCount, h.Config, header)
+	if err != nil {
+		return nil, err
+	}
 
 	stream, err := stt.Start(ctx, packetReader)
 	if err != nil {

--- a/test_handler.go
+++ b/test_handler.go
@@ -73,7 +73,7 @@ func (h *TestHandler) ResetRetryCount() int {
 	return h.RetryCount
 }
 
-func (h *TestHandler) Handle(ctx context.Context, opusCh chan opusChannel) (*io.PipeReader, error) {
+func (h *TestHandler) Handle(ctx context.Context, opusCh chan opusChannel, header soraHeader) (*io.PipeReader, error) {
 	r, w := io.Pipe()
 
 	reader := opusChannelToIOReadCloser(ctx, opusCh)


### PR DESCRIPTION
This pull request includes several changes to enhance the functionality and flexibility of the audio processing system, specifically by adding support for saving audio data as Ogg files and handling additional header information.

### Enhancements to audio processing:

* `amazon_transcribe_handler.go`, `packet_dump_handler.go`, `speech_to_text_handler.go`, `test_handler.go`, `service_handler.go`: Modified the `Handle` method signatures to include a `soraHeader` parameter for handling additional header information. [[1]](diffhunk://#diff-80a00097f4667531152763b63d79bf825afac92654271ce6554444bb3d5efc1dL99-R105) [[2]](diffhunk://#diff-b0ae806cf93a35f7577b0c3aa74ba2fc0248205d061c53fbf3bec01e3988493eL70-R70) [[3]](diffhunk://#diff-5d22d7606a787cb1db0f9664215935bf23dfbbfd2d2f766f36b1ebf9ef41ab91L94-R100) [[4]](diffhunk://#diff-986505ee220899861ae869b60aa0c4c761393426efc7c818b724e0e5c30f029aL76-R76) [[5]](diffhunk://#diff-0aaeb79526508fcf42468b5d538b04a16fa0b21334eda98b33deb41449ab558dL18-R18)
* [`handler.go`](diffhunk://#diff-0eb779b9e49d8e44b0f36923fdb8d87d5ee024f886eefc45deec4ec88380a087R46-R55): Added a new `soraHeader` struct to encapsulate header information, and updated relevant methods to utilize this struct. [[1]](diffhunk://#diff-0eb779b9e49d8e44b0f36923fdb8d87d5ee024f886eefc45deec4ec88380a087R46-R55) [[2]](diffhunk://#diff-0eb779b9e49d8e44b0f36923fdb8d87d5ee024f886eefc45deec4ec88380a087L68-R80) [[3]](diffhunk://#diff-0eb779b9e49d8e44b0f36923fdb8d87d5ee024f886eefc45deec4ec88380a087L156-R160)

### Ogg file output support:

* `config.go`, `config_example.ini`: Added new configuration options `EnableOggFileOutput` and `OggDir` to control the output of Ogg files and specify the directory for saving them. [[1]](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249R68-R70) [[2]](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249R179-R182) [[3]](diffhunk://#diff-b85f5cca5558e6035d7f3fd0aa138ab1b719fa05e562a61c27ad75fe7a760d94R58-R61)
* [`handler.go`](diffhunk://#diff-0eb779b9e49d8e44b0f36923fdb8d87d5ee024f886eefc45deec4ec88380a087L462-R498): Updated the `opus2ogg` function to support writing Ogg files to disk when enabled, and handle potential errors such as missing directories or permission issues. [[1]](diffhunk://#diff-0eb779b9e49d8e44b0f36923fdb8d87d5ee024f886eefc45deec4ec88380a087L462-R498) [[2]](diffhunk://#diff-0eb779b9e49d8e44b0f36923fdb8d87d5ee024f886eefc45deec4ec88380a087L504-R530)

### Testing:

* [`handler_test.go`](diffhunk://#diff-39de3493ae7887b6c07ddf65fc59c005b3f2fccc9b06da022954597de5b12d7cR317-R462): Added new tests to verify the functionality of Ogg file writing, including scenarios for successful writes, disabled output, permission errors, and non-existent directories.