### PR TITLE
ログに sessionID を追加する

### DIFF
--- a/amazon_transcribe.go
+++ b/amazon_transcribe.go
@@ -141,7 +141,7 @@ func (at *AmazonTranscribe) Start(ctx context.Context, r io.ReadCloser) (*transc
 		defer stream.Close()
 
 		if err := transcribestreamingservice.StreamAudioFromReader(ctx, stream, FrameSize, r); err != nil {
-			zlog.Error().Err(err).Send()
+			zlog.Error().Err(err).Str("session_id", at.SessionID).Send()
 			return
 		}
 	}()

--- a/amazon_transcribe.go
+++ b/amazon_transcribe.go
@@ -22,6 +22,7 @@ type AmazonTranscribe struct {
 	EnableChannelIdentification       bool
 	PartialResultsStability           string
 	Region                            string
+	SessionID                         string
 	Debug                             bool
 	Config                            Config
 }
@@ -127,6 +128,10 @@ func (at *AmazonTranscribe) Start(ctx context.Context, r io.ReadCloser) (*transc
 			}
 		}
 		return nil, err
+	}
+
+	if resp.SessionId != nil {
+		at.SessionID = *resp.SessionId
 	}
 
 	stream := resp.GetStream()

--- a/amazon_transcribe_handler.go
+++ b/amazon_transcribe_handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"sync"
@@ -209,7 +210,8 @@ func (h *AmazonTranscribeHandler) Handle(ctx context.Context, opusCh chan opusCh
 				Send()
 
 			if h.IsRetryTarget(err) {
-				err = errors.Join(err, ErrServerDisconnected)
+				errWithSessionID := fmt.Errorf("%w (session_id: %s)", err, at.SessionID)
+				err = errors.Join(errWithSessionID, ErrServerDisconnected)
 			}
 
 			w.CloseWithError(err)

--- a/amazon_transcribe_handler.go
+++ b/amazon_transcribe_handler.go
@@ -153,6 +153,7 @@ func (h *AmazonTranscribeHandler) Handle(ctx context.Context, opusCh chan opusCh
 									Err(err).
 									Str("channel_id", h.ChannelID).
 									Str("connection_id", h.ConnectionID).
+									Str("session_id", at.SessionID).
 									Send()
 							}
 							w.CloseWithError(err)
@@ -203,6 +204,7 @@ func (h *AmazonTranscribeHandler) Handle(ctx context.Context, opusCh chan opusCh
 				Err(err).
 				Str("channel_id", h.ChannelID).
 				Str("connection_id", h.ConnectionID).
+				Str("session_id", at.SessionID).
 				Int("retry_count", h.GetRetryCount()).
 				Send()
 

--- a/amazon_transcribe_v2_handler.go
+++ b/amazon_transcribe_v2_handler.go
@@ -154,6 +154,7 @@ func (h *AmazonTranscribeV2Handler) Handle(ctx context.Context, opusCh chan opus
 									Err(err).
 									Str("channel_id", h.ChannelID).
 									Str("connection_id", h.ConnectionID).
+									Str("session_id", at.SessionID).
 									Send()
 							}
 							w.CloseWithError(err)
@@ -204,6 +205,7 @@ func (h *AmazonTranscribeV2Handler) Handle(ctx context.Context, opusCh chan opus
 				Err(err).
 				Str("channel_id", h.ChannelID).
 				Str("connection_id", h.ConnectionID).
+				Str("session_id", at.SessionID).
 				Int("retry_count", h.GetRetryCount()).
 				Send()
 

--- a/amazon_transcribe_v2_handler.go
+++ b/amazon_transcribe_v2_handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"sync"
@@ -210,7 +211,8 @@ func (h *AmazonTranscribeV2Handler) Handle(ctx context.Context, opusCh chan opus
 				Send()
 
 			if ok := h.IsRetryTarget(err); ok {
-				err = errors.Join(err, ErrServerDisconnected)
+				errWithSessionID := fmt.Errorf("%w (session_id: %s)", err, at.SessionID)
+				err = errors.Join(errWithSessionID, ErrServerDisconnected)
 			}
 
 			w.CloseWithError(err)


### PR DESCRIPTION
This pull request introduces functionality to track and log the `SessionID` for both `AmazonTranscribe` and `AmazonTranscribeV2`. The changes enhance error logging and debugging by including the `SessionID` in log messages and error handling. Below are the key updates:

### `SessionID` Tracking and Logging:

* **Added `SessionID` field** to the `AmazonTranscribe` and `AmazonTranscribeV2` structs to store the session identifier. (`amazon_transcribe.go`: [[1]](diffhunk://#diff-2ac3c9a3c09967cccffebb06738362418de6bbf4d7929dbddb7e70a392917de1R25) `amazon_transcribe_v2.go`: [[2]](diffhunk://#diff-6f6fbef239ec0d6fa3468c3cc7e7030ce979f89989a6930ab4d3a39da82c766eR28)

* **Populated `SessionID`** from the `SessionId` field in the response object during the `Start` method in both `AmazonTranscribe` and `AmazonTranscribeV2`. (`amazon_transcribe.go`: [[1]](diffhunk://#diff-2ac3c9a3c09967cccffebb06738362418de6bbf4d7929dbddb7e70a392917de1R133-R144) `amazon_transcribe_v2.go`: [[2]](diffhunk://#diff-6f6fbef239ec0d6fa3468c3cc7e7030ce979f89989a6930ab4d3a39da82c766eR147-R157)

### Enhanced Logging:

* **Included `SessionID` in log messages** for error reporting in `AmazonTranscribe` and `AmazonTranscribeV2`. This ensures better traceability of errors. (`amazon_transcribe.go`: [[1]](diffhunk://#diff-2ac3c9a3c09967cccffebb06738362418de6bbf4d7929dbddb7e70a392917de1R133-R144) `amazon_transcribe_v2.go`: [[2]](diffhunk://#diff-6f6fbef239ec0d6fa3468c3cc7e7030ce979f89989a6930ab4d3a39da82c766eL161-R166) [[3]](diffhunk://#diff-6f6fbef239ec0d6fa3468c3cc7e7030ce979f89989a6930ab4d3a39da82c766eL172-R177)

* **Updated handlers (`AmazonTranscribeHandler` and `AmazonTranscribeV2Handler`)** to log `SessionID` alongside other context information such as `channel_id` and `connection_id`. (`amazon_transcribe_handler.go`: [[1]](diffhunk://#diff-80a00097f4667531152763b63d79bf825afac92654271ce6554444bb3d5efc1dR157) [[2]](diffhunk://#diff-80a00097f4667531152763b63d79bf825afac92654271ce6554444bb3d5efc1dR208-R214) `amazon_transcribe_v2_handler.go`: [[3]](diffhunk://#diff-00038c9a983c1959678ed45787886f58b6f0ebd1325f9da432cc271c18375f47R158) [[4]](diffhunk://#diff-00038c9a983c1959678ed45787886f58b6f0ebd1325f9da432cc271c18375f47R209-R215)

### Error Handling Improvements:

* **Appended `SessionID` to error messages** when joining errors in the retry handling logic, improving the clarity of error context. (`amazon_transcribe_handler.go`: [[1]](diffhunk://#diff-80a00097f4667531152763b63d79bf825afac92654271ce6554444bb3d5efc1dR208-R214) `amazon_transcribe_v2_handler.go`: [[2]](diffhunk://#diff-00038c9a983c1959678ed45787886f58b6f0ebd1325f9da432cc271c18375f47R209-R215)

### Miscellaneous:

* **Imported the `fmt` package** in the handler files to format error messages. (`amazon_transcribe_handler.go`: [[1]](diffhunk://#diff-80a00097f4667531152763b63d79bf825afac92654271ce6554444bb3d5efc1dR7) `amazon_transcribe_v2_handler.go`: [[2]](diffhunk://#diff-00038c9a983c1959678ed45787886f58b6f0ebd1325f9da432cc271c18375f47R7)