### PR TITLE
config.ini に aws_profile が指定されていない場合にも、config.ini の HTTPClient 関連設定を有効にする

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,7 +39,7 @@
   - @Hexa
 - [FIX] config.ini で aws_profile が設定されていない場合でも、config.ini に設定した HTTPClient 関連の設定を反映する
   - @Hexa
-- [CHANGE] aws_profile が設定されていない場合でも debug 設定が反映されるように変更する
+- [FIX] aws_profile が設定されていない場合でも debug 設定が反映されるように変更する
   - @Hexa
 
 ### misc

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,8 @@
   - @Hexa
 - [FIX] config.ini で aws_profile が設定されていない場合でも、config.ini に設定した HTTPClient 関連の設定を反映する
   - @Hexa
+- [CHANGE] aws_profile が設定されていない場合でも debug 設定が反映されるように変更する
+  - @Hexa
 
 ### misc
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,9 +37,8 @@
   - @Hexa
 - [CHANGE] 外部サービス接続処理時のエラーなどにより HTTP ステータスコードが 3 桁以外の場合は、クライアントに InternalServerError を返す
   - @Hexa
-- [CHANGE] config.ini で aws_profile が設定されていない場合でも、config.ini に設定した HTTPClient 関連の設定を反映する
+- [FIX] config.ini で aws_profile が設定されていない場合でも、config.ini に設定した HTTPClient 関連の設定を反映する
   - @Hexa
-
 
 ### misc
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,9 @@
   - @Hexa
 - [CHANGE] 外部サービス接続処理時のエラーなどにより HTTP ステータスコードが 3 桁以外の場合は、クライアントに InternalServerError を返す
   - @Hexa
+- [CHANGE] config.ini で aws_profile が設定されていない場合でも、config.ini に設定した HTTPClient 関連の設定を反映する
+  - @Hexa
+
 
 ### misc
 

--- a/amazon_transcribe_v2.go
+++ b/amazon_transcribe_v2.go
@@ -90,27 +90,23 @@ func NewAmazonTranscribeClientV2(c Config) (*transcribestreaming.Client, error) 
 		clientLogMode = aws.LogSigning | aws.LogRetries | aws.LogRequest | aws.LogRequestWithBody | aws.LogResponse | aws.LogResponseWithBody | aws.LogDeprecatedUsage | aws.LogRequestEventMessage | aws.LogResponseEventMessage
 	}
 
-	var cfg aws.Config
+	loadOptions := []func(*config.LoadOptions) error{
+		config.WithRegion(c.AwsRegion),
+		config.WithHTTPClient(httpClient),
+		config.WithClientLogMode(clientLogMode),
+	}
+
+	if c.AwsCredentialFile != "" {
+		loadOptions = append(loadOptions, config.WithSharedCredentialsFiles([]string{c.AwsCredentialFile}))
+	}
+
 	if c.AwsProfile != "" {
-		var err error
-		cfg, err = config.LoadDefaultConfig(ctx,
-			config.WithRegion(c.AwsRegion),
-			config.WithSharedConfigProfile(c.AwsProfile),
-			config.WithSharedCredentialsFiles([]string{c.AwsCredentialFile}),
-			config.WithHTTPClient(httpClient),
-			config.WithClientLogMode(clientLogMode),
-		)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		var err error
-		cfg, err = config.LoadDefaultConfig(ctx,
-			config.WithRegion(c.AwsRegion),
-		)
-		if err != nil {
-			return nil, err
-		}
+		loadOptions = append(loadOptions, config.WithSharedConfigProfile(c.AwsProfile))
+	}
+
+	cfg, err := config.LoadDefaultConfig(ctx, loadOptions...)
+	if err != nil {
+		return nil, err
 	}
 
 	client := transcribestreaming.NewFromConfig(cfg)

--- a/amazon_transcribe_v2.go
+++ b/amazon_transcribe_v2.go
@@ -96,11 +96,10 @@ func NewAmazonTranscribeClientV2(c Config) (*transcribestreaming.Client, error) 
 		config.WithClientLogMode(clientLogMode),
 	}
 
-	if c.AwsCredentialFile != "" {
-		loadOptions = append(loadOptions, config.WithSharedCredentialsFiles([]string{c.AwsCredentialFile}))
-	}
-
 	if c.AwsProfile != "" {
+		if c.AwsCredentialFile != "" {
+			loadOptions = append(loadOptions, config.WithSharedCredentialsFiles([]string{c.AwsCredentialFile}))
+		}
 		loadOptions = append(loadOptions, config.WithSharedConfigProfile(c.AwsProfile))
 	}
 

--- a/amazon_transcribe_v2_test.go
+++ b/amazon_transcribe_v2_test.go
@@ -1,0 +1,80 @@
+package suzu
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewAmazonTranscribeClientV2_WithoutProfile_AppliesHTTPClientAndLogMode(t *testing.T) {
+	t.Setenv("AWS_ACCESS_KEY_ID", "dummy-access-key")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "dummy-secret-key")
+
+	c := Config{
+		Debug:                          true,
+		AwsRegion:                      "ap-northeast-1",
+		AwsHTTPDisableKeepAlives:       true,
+		AwsHTTPIdleConnTimeoutSec:      90,
+		AwsHTTPMaxIdleConns:            100,
+		AwsHTTPMaxIdleConnsPerHost:     10,
+		AwsHTTPMaxConnsPerHost:         20,
+		AwsHTTPResponseHeaderTimeoutMs: 1234,
+		AwsHTTPExpectContinueTimeoutMs: 567,
+		AwsHTTPTLSHandshakeTimeoutMs:   8901,
+	}
+
+	client, err := NewAmazonTranscribeClientV2(c)
+	require.NoError(t, err)
+
+	opts := client.Options()
+	require.NotNil(t, opts.HTTPClient)
+	assert.NotEqual(t, 0, int(opts.ClientLogMode))
+
+	httpClient, ok := opts.HTTPClient.(*http.Client)
+	require.True(t, ok)
+
+	tr, ok := httpClient.Transport.(*http.Transport)
+	require.True(t, ok)
+	assert.Equal(t, c.AwsHTTPDisableKeepAlives, tr.DisableKeepAlives)
+	assert.Equal(t, time.Duration(c.AwsHTTPIdleConnTimeoutSec)*time.Second, tr.IdleConnTimeout)
+	assert.Equal(t, c.AwsHTTPMaxIdleConns, tr.MaxIdleConns)
+	assert.Equal(t, c.AwsHTTPMaxIdleConnsPerHost, tr.MaxIdleConnsPerHost)
+	assert.Equal(t, c.AwsHTTPMaxConnsPerHost, tr.MaxConnsPerHost)
+	assert.Equal(t, time.Duration(c.AwsHTTPResponseHeaderTimeoutMs)*time.Millisecond, tr.ResponseHeaderTimeout)
+	assert.Equal(t, time.Duration(c.AwsHTTPExpectContinueTimeoutMs)*time.Millisecond, tr.ExpectContinueTimeout)
+	assert.Equal(t, time.Duration(c.AwsHTTPTLSHandshakeTimeoutMs)*time.Millisecond, tr.TLSHandshakeTimeout)
+}
+
+func TestNewAmazonTranscribeClientV2_WithProfile_UsesCredentialFile(t *testing.T) {
+	t.Setenv("AWS_ACCESS_KEY_ID", "")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+	t.Setenv("HOME", t.TempDir())
+
+	credentialFilePath := filepath.Join(t.TempDir(), "credentials")
+	credentialFile := `[profile-a]
+aws_access_key_id = profile-a-access-key
+aws_secret_access_key = profile-a-secret-key
+`
+	err := os.WriteFile(credentialFilePath, []byte(credentialFile), 0o600)
+	require.NoError(t, err)
+
+	c := Config{
+		AwsRegion:         "ap-northeast-1",
+		AwsProfile:        "profile-a",
+		AwsCredentialFile: credentialFilePath,
+	}
+
+	client, err := NewAmazonTranscribeClientV2(c)
+	require.NoError(t, err)
+
+	creds, err := client.Options().Credentials.Retrieve(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "profile-a-access-key", creds.AccessKeyID)
+	assert.Equal(t, "profile-a-secret-key", creds.SecretAccessKey)
+}


### PR DESCRIPTION
This pull request improves how AWS client configuration is handled, ensuring that HTTP client and debug settings from `config.ini` are always respected, even if `aws_profile` is not set. It also adds comprehensive tests to verify these behaviors.

**Configuration handling improvements:**

* Refactored `NewAmazonTranscribeClientV2` in `amazon_transcribe_v2.go` to always apply HTTP client and log mode settings from `config.ini`, even when `aws_profile` is not specified. The AWS config loading logic is now more flexible and robust, with conditional inclusion of credential files and profiles.
* Ensured that debug settings from `config.ini` are respected regardless of whether `aws_profile` is set.

**Testing enhancements:**

* Added new tests in `amazon_transcribe_v2_test.go` to verify that HTTP client and log mode settings are applied when no profile is set, and that the correct credentials are used when a profile and credential file are specified.

**Documentation:**

* Updated `CHANGES.md` to reflect the bug fixes regarding HTTP client and debug settings application.